### PR TITLE
Add New Configs/Revocation Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,6 @@ Want to help support me in maintaining TESjs? Consider sponsoring me on [GitHub 
         <img src="https://github.githubassets.com/images/modules/site/sponsors/logo-mona-2.svg" height="75px" alt="GH Sponsors">
     </a>
 </p>
+
+# Community
+Have you made something with TESjs?  I'd love to hear about it!  You can tweet me [@imMtB_](https://twitter.com/imMtB_) and show off your project.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -19,6 +19,10 @@ The configuration object is required as an argument when creating the TESjs inst
   - Keep in mind, this is the port of the Express http server, not your https endpoint (served at `baseURL`) which should have port 443
 - `server`: *Express App* - (Optional) your express app object
   - Used if integrating TESjs with an existing Express app
+- `ignoreDuplicateMessages`: *boolean* - (Optional) ignore messages with ids that have already been seen
+  - defaults to true
+- `ignoreOldMessages`: *boolean* - (Optional) ignore messages with timestamps older than 10 minutes
+  - defaults to true
 
 ## Examples
 ### Barebones

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -6,7 +6,9 @@ The configuration object is required as an argument when creating the TESjs inst
 
 `options`: (Optional) Your basic configuration options
 - `debug`: *boolean* - (Optional) set to true for more in-depth logging
+  - defaults to false
 - `logging`: *boolean* - (Optional) set to false for no logging. Takes precendence over debug
+  - defaults to true
 
 `identity`: (Required) Set up your client's identity
 - `id`: *string* - (Required) your app's client id
@@ -15,7 +17,8 @@ The configuration object is required as an argument when creating the TESjs inst
 `listener`: (Required) Setting your notification listener details
 - `baseURL`: *string* - (Required) the url where your endpoint is hosted
   - See [Twitch doc](https://dev.twitch.tv/docs/eventsub) for details on local development
-- `port`: *number* - (Optional) the port to listen at. Defaults to process.env.PORT or 8080
+- `port`: *number* - (Optional) the port to listen at.
+  - defaults to process.env.PORT or 8080
   - Keep in mind, this is the port of the Express http server, not your https endpoint (served at `baseURL`) which should have port 443
 - `server`: *Express App* - (Optional) your express app object
   - Used if integrating TESjs with an existing Express app

--- a/doc/events.md
+++ b/doc/events.md
@@ -37,5 +37,6 @@ According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subs
 ```js
 tes.on('revocation', (subscriptionId, status, type, version, condition, transport, createdAt) => {
     console.log(`subscription with ${subscriptionId} has been revoked`);
+    // perform cleanup here
 });
 ```

--- a/doc/events.md
+++ b/doc/events.md
@@ -31,3 +31,11 @@ tes.on('channel.ban', (userId, userName, broadcasterId, broadcasterName) => {
   // do your things here
 });
 ```
+
+## Subscription Revocation
+According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
+```js
+tes.on('revocation', (subscriptionId, status, type, version, condition, transport, createdAt) => {
+    console.log(`subscription with ${subscriptionId} has been revoked`);
+});
+```

--- a/doc/events.md
+++ b/doc/events.md
@@ -36,7 +36,7 @@ tes.on('channel.ban', (userId, userName, broadcasterId, broadcasterName) => {
 According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
 ```js
 tes.on('revocation', (subscriptionId, status, type, version, condition, transport, createdAt) => {
-    console.log(`subscription with ${subscriptionId} has been revoked`);
+    console.log(`subscription with id ${subscriptionId} has been revoked`);
     // perform cleanup here
 });
 ```

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -33,7 +33,11 @@ class TES {
 
         this.baseURL = config.listener.baseURL;
         this.port = config.listener.port || process.env.PORT || 8080;
-        this.whserver = whserver(config.listener.server, this.clientSecret);
+        const serverConfig = {
+            ignoreDuplicateMessages: config.listener.ignoreDuplicateMessages,
+            ignoreOldMessages: config.listener.ignoreOldMessages
+        }
+        this.whserver = whserver(config.listener.server, this.clientSecret, serverConfig);
         this._whserverlistener = config.listener.server ? null : this.whserver.listen(this.port);
 
         config.options.debug && logger.setLevel('debug');

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -34,8 +34,8 @@ class TES {
         this.baseURL = config.listener.baseURL;
         this.port = config.listener.port || process.env.PORT || 8080;
         const serverConfig = {
-            ignoreDuplicateMessages: config.listener.ignoreDuplicateMessages,
-            ignoreOldMessages: config.listener.ignoreOldMessages
+            ignoreDuplicateMessages: config.listener.ignoreDuplicateMessages === false ? false : true,
+            ignoreOldMessages: config.listener.ignoreOldMessages === false ? false : true
         }
         this.whserver = whserver(config.listener.server, this.clientSecret, serverConfig);
         this._whserverlistener = config.listener.server ? null : this.whserver.listen(this.port);

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -47,13 +47,20 @@ module.exports = function(server, secret) {
                 // if normal event, send OK and handle event
                 res.status(200).send('OK');
 
-                // if the request is not revoking the subscription, fire the event
-                if (req.headers['twitch-eventsub-message-type'] !== 'revocation') {
-                    logger.log(`Received notification for type ${req.body.subscription.type}`);
-                    EventManager.fire(req.body.subscription.type, req.body.event);
-                    return;
+                // handle different message types
+                switch (req.headers['twitch-eventsub-message-type']) {
+                    case 'notification':
+                        logger.log(`Received notification for type ${req.body.subscription.type}`);
+                        EventManager.fire(req.body.subscription.type, req.body.event);
+                        break;
+                    case 'revocation':
+                        logger.log(`Received revocation notification for subscription id ${req.body.subscription.id}`);
+                        EventManager.fire('revocation', req.body.subscription);
+                        break;
+                    default:
+                        logger.log(`Received request with unhandled message type ${req.headers['twitch-eventsub-message-type']}`);
+                        break;
                 }
-                logger.log(`Received revocation notification for subscription id ${req.body.subscription.id}`);
             } else {
                 logger.debug(`Request message signature ${req.twitch_signature} does not match calculated signature ${req.calculated_signature}`);
                 res.status(401).send('Request signature mismatch');

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -51,11 +51,13 @@ module.exports = function(server, secret, config) {
                 // handle dupes and old messages (per config)
                 let canFire = true;
                 const messageId = req.headers['twitch-eventsub-message-id'];
-                if (config.ignoreDuplicateMessages === true && recentMessageIds[messageId]) {
+                if (config.ignoreDuplicateMessages && recentMessageIds[messageId]) {
+                    logger.debug(`Received duplicate notification with message id ${messageId}`);
                     canFire = false;
                 }
                 const messageAge = Date.now() - new Date(req.headers['twitch-eventsub-message-timestamp']);
-                if (config.ignoreOldMessages === true && messageAge > 600000) {
+                if (config.ignoreOldMessages && messageAge > 600000) {
+                    logger.debug(`Received old notification with message id ${messageId}`);
                     canFire = false;
                 }
 

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -29,8 +29,9 @@ const verify = (secret, req, res, buf, encoding) => {
     }
 }
 
-module.exports = function(server, secret) {
+module.exports = function(server, secret, config) {
     const whserver = server || express();
+    let recentMessageIds = {};
 
     whserver.post('/teswh/event', bodyParser.json({verify: (req, res, buf, encoding) => {verify(secret, req, res, buf, encoding)}}), (req, res) => {
         // check if our middleware detected a request from Twitch
@@ -47,19 +48,36 @@ module.exports = function(server, secret) {
                 // if normal event, send OK and handle event
                 res.status(200).send('OK');
 
-                // handle different message types
-                switch (req.headers['twitch-eventsub-message-type']) {
-                    case 'notification':
-                        logger.log(`Received notification for type ${req.body.subscription.type}`);
-                        EventManager.fire(req.body.subscription.type, req.body.event);
-                        break;
-                    case 'revocation':
-                        logger.log(`Received revocation notification for subscription id ${req.body.subscription.id}`);
-                        EventManager.fire('revocation', req.body.subscription);
-                        break;
-                    default:
-                        logger.log(`Received request with unhandled message type ${req.headers['twitch-eventsub-message-type']}`);
-                        break;
+                // handle dupes and old messages (per config)
+                let canFire = true;
+                const messageId = req.headers['twitch-eventsub-message-id'];
+                if (config.ignoreDuplicateMessages === true && recentMessageIds[messageId]) {
+                    canFire = false;
+                }
+                const messageAge = Date.now() - new Date(req.headers['twitch-eventsub-message-timestamp']);
+                if (config.ignoreOldMessages === true && messageAge > 600000) {
+                    canFire = false;
+                }
+
+                if (canFire) {
+                    // handle different message types
+                    switch (req.headers['twitch-eventsub-message-type']) {
+                        case 'notification':
+                            logger.log(`Received notification for type ${req.body.subscription.type}`);
+                            recentMessageIds[messageId] = true;
+                            setTimeout(_ => {delete recentMessageIds[messageId]}, 601000);
+                            EventManager.fire(req.body.subscription.type, req.body.event);
+                            break;
+                        case 'revocation':
+                            logger.log(`Received revocation notification for subscription id ${req.body.subscription.id}`);
+                            recentMessageIds[messageId] = true;
+                            setTimeout(_ => {delete recentMessageIds[messageId]}, 601000);
+                            EventManager.fire('revocation', req.body.subscription);
+                            break;
+                        default:
+                            logger.log(`Received request with unhandled message type ${req.headers['twitch-eventsub-message-type']}`);
+                            break;
+                    }
                 }
             } else {
                 logger.debug(`Request message signature ${req.twitch_signature} does not match calculated signature ${req.calculated_signature}`);

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -63,7 +63,7 @@ module.exports = function(server, secret) {
                 }
             } else {
                 logger.debug(`Request message signature ${req.twitch_signature} does not match calculated signature ${req.calculated_signature}`);
-                res.status(401).send('Request signature mismatch');
+                res.status(403).send('Request signature mismatch');
             }
         } else {
             logger.debug('Received unauthorized request to webhooks endpoint');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -133,9 +133,9 @@ describe('whserver', _ => {
             });
     });
 
-    it('responds with 200 OK when receiving a revocation and the event should not be fired', done => {
+    it('responds with 200 OK when receiving a revocation and the revocation event should be fired', done => {
         let notificationRecieved = false;
-        tes.on('channel.follow', _ => {
+        tes.on('revocation', _ => {
             notificationRecieved = true;
         });
         const payload = {
@@ -176,7 +176,7 @@ describe('whserver', _ => {
             .end((err, res) => {
                 if (err) return done(err);
                 res.text.should.eq('OK');
-                notificationRecieved.should.eq(false);
+                notificationRecieved.should.eq(true);
                 done();
             });
     });
@@ -259,12 +259,12 @@ describe('whserver', _ => {
         }
         const oldTime = new Date(Date.now() - 601000).toISOString()
         const signature = crypto.createHmac('sha256', secret)
-            .update('befa7b53-d79d-478f-86b9-120f112b044e' + oldTime + Buffer.from(JSON.stringify(payload), 'utf-8'))
+            .update('befa7b53-d79d-478f-86b9-120f112b044d' + oldTime + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)
             .post('/teswh/event')
             .set({
-                'Twitch-Eventsub-Message-Id': 'befa7b53-d79d-478f-86b9-120f112b044e',
+                'Twitch-Eventsub-Message-Id': 'befa7b53-d79d-478f-86b9-120f112b044d',
                 'Twitch-Eventsub-Message-Retry': 0,
                 'Twitch-Eventsub-Message-Type': 'notification',
                 'Twitch-Eventsub-Message-Signature': `sha256=${signature}`,

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -36,7 +36,7 @@ describe('whserver', _ => {
                 'Twitch-Eventsub-Subscription-Version': 1
             })
             .send({})
-            .expect(401, done);
+            .expect(403, done);
     });
 
     it('responds with challenge when challenged', done => {


### PR DESCRIPTION
# Description
This PR adds two new config options to the listener which enable ignoring webhooks requests with duplicate message ids and those with timestamps older than 10 minutes.  In addition to this, it adds an event that gets fired when a subscription gets revoked, enabling developers to perform any necessary cleanup which may be needed when a revocation happens.

## Additions
- a configurable option `ignoreDuplicateMessages` in `listener` config
  - closes #8 
- a configurable option `ignoreOldMessages` in `listener` config
  - closes #9 
- an event gets fired when a subscription gets revoked
  - closes #7

## Changes
- signature mismatch now responds with a 403 instead of a 401 in `whserver`\
- add community section to README
- doc changes for updated functionality
- test changes for updated functionality
  
## Testing
Updated tests to cover new cases
