### PR TITLE
Add new getSubscriptions Functions, Change Handler Payload, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ const tes = new TES({
 // NOTES: 
 //   this handles ALL events of that type
 //   events will not be fired until there is a subscription made for them
-tes.on('channel.update', (userId, userLogin, userName, title, language, categoryId, categoryName, isMature) => {
-    console.log(`${userName}'s new title is ${title}`);
+tes.on('channel.update', event => {
+    console.log(`${event.broadcaster_user_name}'s new title is ${event.title}`);
 });
 
 // create a new subscription for the 'channel.update' event for broadcaster '1337'
@@ -84,8 +84,8 @@ const tes = new TES({
 // NOTES: 
 //   this handles ALL events of that type
 //   events will not be fired until there is a subscription made for them
-tes.on('channel.update', (userId, userLogin, userName, title, language, categoryId, categoryName, isMature) => {
-    console.log(`${userName}'s new title is ${title}`);
+tes.on('channel.update', event => {
+    console.log(`${event.broadcaster_user_name}'s new title is ${event.title}`);
 });
 
 // create a new subscription for the 'channel.update' event for broadcaster '1337'

--- a/doc/events.md
+++ b/doc/events.md
@@ -34,6 +34,7 @@ tes.on('channel.ban', event => {
 
 ## Subscription Revocation
 According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
+**NOTE:** As this 'event' is fired when a currently subscribed event topic is revoked, no explicit subscription is needed for this event.
 ```js
 tes.on('revocation', event => {
     console.log(`subscription with id ${event.id} has been revoked`);

--- a/doc/events.md
+++ b/doc/events.md
@@ -36,8 +36,8 @@ tes.on('channel.ban', event => {
 According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
 **NOTE:** As this 'event' is fired when a currently subscribed event topic is revoked, no explicit subscription is needed for this event.
 ```js
-tes.on('revocation', event => {
-    console.log(`subscription with id ${event.id} has been revoked`);
-    // perform cleanup here
+tes.on('revocation', subscriptionData => {
+    console.log(`subscription with id ${subscriptionData.id} has been revoked`);
+    // perform necessary cleanup here
 });
 ```

--- a/doc/events.md
+++ b/doc/events.md
@@ -17,26 +17,26 @@ const tes = new TES({
 });
 
 // an example of an event handler for the 'channel.update' event
-tes.on('channel.update', (userId, userLogin, userName, title, language, categoryId, categoryName, isMature) => {
-    console.log(`${userName}'s new title is ${title}`);
+tes.on('channel.update', event => {
+    console.log(`${event.broadcaster_user_name}'s new title is ${event.title}`);
 });
 ```
 
 ## Event Types
-Event type names can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types).  Events and their respective parameters can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-reference#events).  When creating a handler for any event, the order of arguments to the handler function is reflected in the order they are listed in the documentation.
+Event type names can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types).  Events and their respective parameters can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-reference#events).
 
-For example, the `channel.ban` [event](https://dev.twitch.tv/docs/eventsub/eventsub-reference#channel-ban-event) has four parameters `user_id, user_name, broadcaster_user_id, broadcaster_user_name`.  The event handler would be created like so:
+For example, the `channel.ban` [event](https://dev.twitch.tv/docs/eventsub/eventsub-reference#channel-ban-event) has four parameters `user_id, user_login, user_name, broadcaster_user_id, broadcaster_user_login, broadcaster_user_name`.  The event handler would be created like so:
 ```js
-tes.on('channel.ban', (userId, userLogin, userName, broadcasterId, broadcasterLogin, broadcasterName) => {
-  // do your things here
+tes.on('channel.ban', event => {
+  console.log(`${event.user_name} with id ${event.user_id} and login ${event.user_login} was banned from channel ${event.broadcaster_user_name} with id ${event.broadcaster_user_id} and login ${event.broadcaster_user_login}`)
 });
 ```
 
 ## Subscription Revocation
 According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
 ```js
-tes.on('revocation', (subscriptionId, status, type, version, condition, transport, createdAt) => {
-    console.log(`subscription with id ${subscriptionId} has been revoked`);
+tes.on('revocation', event => {
+    console.log(`subscription with id ${event.id} has been revoked`);
     // perform cleanup here
 });
 ```

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -7,6 +7,10 @@ The functions included with TESjs
   - By type and condition
 - [getSubscriptions](#getsubscriptions) - Get a list of subscriptions
   - With pagination
+- [getSubscriptionsByType](#getsubscriptionsbytype) - Get a list of subscriptions by type
+  - With pagination
+- [getSubscriptionsByStatus](#getsubscriptionsbystatus) - Get a list of subscriptions by status
+  - With pagination
 - [subscribe](#subscribe) - Subscribe to a topic
 - [unsubscribe](#unsubscribe) - Unsubscribe to a topic
   - By id
@@ -60,6 +64,56 @@ let subsArray = []
 //define a recursive function to get ALL subscriptions
 const getAll = (finishedCallback, cursor) => {
   tes.getSubscriptions(cursor).then(data => {
+    subsArray = subsArray.concat(data.data);
+    if (data.pagination.cursor)
+      getAll(callback, data.pagination.cursor);
+    else
+      callback();
+  });
+}
+//call our function and pass an arrow func that will print our results
+getAll(_ => console.log(subsArray));
+```
+
+## getSubscriptionsByType
+Get a list of your subscriptions of a specific type.  When calling this with no second argument, it will give you the first page of results.
+```js
+tes.getSubscriptionsByType('channel.update').then(data => {
+  console.log(data);
+});
+```
+### With pagination
+Use the optional cursor argument to get a specific page of results
+```js
+let subsArray = []
+//define a recursive function to get ALL subscriptions
+const getAll = (finishedCallback, cursor) => {
+  tes.getSubscriptionsByType('channel.update', cursor).then(data => {
+    subsArray = subsArray.concat(data.data);
+    if (data.pagination.cursor)
+      getAll(callback, data.pagination.cursor);
+    else
+      callback();
+  });
+}
+//call our function and pass an arrow func that will print our results
+getAll(_ => console.log(subsArray));
+```
+
+## getSubscriptionsByStatus
+Get a list of your subscriptions with a certain status.  When calling this with no second argument, it will give you the first page of results.
+```js
+tes.getSubscriptionsByStatus('enabled').then(data => {
+  console.log(data);
+});
+```
+### With pagination
+Use the optional cursor argument to get a specific page of results
+```js
+let subsArray = []
+//define a recursive function to get ALL subscriptions
+const getAll = (finishedCallback, cursor) => {
+  tes.getSubscriptionsByStatus('enabled', cursor).then(data => {
     subsArray = subsArray.concat(data.data);
     if (data.pagination.cursor)
       getAll(callback, data.pagination.cursor);

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -38,7 +38,7 @@ tes.getSubscription('2d9e9f1f-39c3-426d-88f5-9f0251c9bfef').then(data => {
 ### By type and condition
 ```js
 const getCondition = {
-  broadcaster_id: '1337'
+  broadcaster_user_id: '1337'
 }
 
 tes.getSubscription('channel.update', getCondition).then(data => {
@@ -75,14 +75,14 @@ getAll(_ => console.log(subsArray));
 Subscribe to an EventSub topic
 ```js
 const condition = {
-  broadcaster_id: '1337'
+  broadcaster_user_id: '1337'
 }
 tes.subscribe('channel.update', condition)
 ```
 Optionally, you can do something once the subscription has been made, and catch any errors
 ```js
 const condition = {
-  broadcaster_id: '1337'
+  broadcaster_user_id: '1337'
 }
 tes.subscribe('channel.update', condition)
 .then(_ => {
@@ -112,14 +112,14 @@ tes.unsubscribe('2d9e9f1f-39c3-426d-88f5-9f0251c9bfef')
 This method is slightly slower because type and condition are used to find the correct id
 ```js
 const condition = {
-  broadcaster_id: '1337'
+  broadcaster_user_id: '1337'
 }
 tes.unsubscribe('channel.update', condition)
 ```
 Like subscribe, things can be done once unsubscribed
 ```js
 const condition = {
-  broadcaster_id: '1337'
+  broadcaster_user_id: '1337'
 }
 tes.unsubscribe('channel.update', condition)
 .then(_ => {

--- a/lib/events.js
+++ b/lib/events.js
@@ -17,7 +17,7 @@ class EventManager {
             logger.warn(`Recieved event for unhandled type: ${type}`);
             return false;
         } else {
-            handler.call(this, ...Object.values(data));
+            handler.call(this, data);
             return true;
         }
     }

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -51,21 +51,27 @@ class TES {
      */
     getSubscriptions(cursor) {
         logger.debug(`Getting ${cursor ? `subscriptions for cursor ${cursor}` : 'first page of subscriptions'}`);
-        return new Promise((resolve, reject) => {
-            this._refreshAppAccessToken().then(_ => {
-                const headers = {
-                    'Client-ID': this.clientID,
-                    'Authorization': `Bearer ${this._authToken}`
-                }
-                request('GET', `https://api.twitch.tv/helix/eventsub/subscriptions${cursor ? `?after=${cursor}` : ''}`, headers).then(data => {
-                    resolve(data);
-                }).catch(err => {
-                    reject(err);
-                });
-            }).catch(err => {
-                reject(err);
-            });
-        });
+        return this._getSubs(`https://api.twitch.tv/helix/eventsub/subscriptions${cursor ? `?after=${cursor}` : ''}`);
+    }
+    
+    /**
+     * 
+     * @param {string} type the type of the subscriptions to get
+     * @param {*} cursor (optional) the pagination cursor
+     */
+    getSubscriptionsByType(type, cursor) {
+        logger.debug(`Getting ${cursor ? `subscriptions for cursor ${cursor}` : 'first page of subscriptions'} of type ${type}`);
+        return this._getSubs(`https://api.twitch.tv/helix/eventsub/subscriptions?${`type=${encodeURIComponent(type)}`}${cursor ? `&after=${cursor}` : ''}`);
+    }
+
+    /**
+     * 
+     * @param {string} status the status of the subscriptions to get
+     * @param {*} cursor (optional) the pagination cursor
+     */
+    getSubscriptionsByStatus(status, cursor) {
+        logger.debug(`Getting ${cursor ? `subscriptions for cursor ${cursor}` : 'first page of subscriptions'} with status ${status}`);
+        return this._getSubs(`https://api.twitch.tv/helix/eventsub/subscriptions?${`status=${encodeURIComponent(status)}`}${cursor ? `&after=${cursor}` : ''}`);
     }
 
     /**
@@ -95,7 +101,7 @@ class TES {
                 reject('getSubscription must have 1 or 2 arguments');
             }
             const getUntilFound = (callback, cursor) => {
-                this.getSubscriptions(cursor).then(data => {
+                this.getSubscriptionsByType(args[0], cursor).then(data => {
                     const sub = data.data.find(comparator);
                     if (!sub) {
                         if (data.pagination.cursor)
@@ -208,6 +214,24 @@ class TES {
     on(type, callback) {
         logger.debug(`Adding notification listener for type ${type}`);
         EventManager.addListener(type, callback);
+    }
+
+    _getSubs(url) {
+        return new Promise((resolve, reject) => {
+            this._refreshAppAccessToken().then(_ => {
+                const headers = {
+                    'Client-ID': this.clientID,
+                    'Authorization': `Bearer ${this._authToken}`
+                }
+                request('GET', url, headers).then(data => {
+                    resolve(data);
+                }).catch(err => {
+                    reject(err);
+                });
+            }).catch(err => {
+                reject(err);
+            });
+        });
     }
 
     _validateAppAccessToken() {

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -57,7 +57,7 @@ class TES {
     /**
      * 
      * @param {string} type the type of the subscriptions to get
-     * @param {*} cursor (optional) the pagination cursor
+     * @param {string} cursor (optional) the pagination cursor
      */
     getSubscriptionsByType(type, cursor) {
         logger.debug(`Getting ${cursor ? `subscriptions for cursor ${cursor}` : 'first page of subscriptions'} of type ${type}`);
@@ -67,7 +67,7 @@ class TES {
     /**
      * 
      * @param {string} status the status of the subscriptions to get
-     * @param {*} cursor (optional) the pagination cursor
+     * @param {string} cursor (optional) the pagination cursor
      */
     getSubscriptionsByStatus(status, cursor) {
         logger.debug(`Getting ${cursor ? `subscriptions for cursor ${cursor}` : 'first page of subscriptions'} with status ${status}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/events.js
+++ b/test/events.js
@@ -54,9 +54,9 @@ describe('EventManager', _ => {
             arg2: 'test arg2'
         }
         let arg1Actual, arg2Actual;
-        EventManager.addListener('test', (arg1, arg2) => {
-            arg1Actual = arg1;
-            arg2Actual = arg2;
+        EventManager.addListener('test', event => {
+            arg1Actual = event.arg1;
+            arg2Actual = event.arg2;
         });
         EventManager.fire('test', argData).should.eq(true);
         arg1Actual.should.eq('test arg1');


### PR DESCRIPTION
# Description
This PR adds a couple of new getSubscriptions functions described in #17.  It also changes the event handler payload to be the event object rather than spreading the event into separate arguments because it is not guaranteed to be the same order each time.  This will also set TESjs up to be more resilient to EventSub changes in the future (see #18).

This PR also includes doc changes for the above, as well as a fix for inconsistency described in #19.

## Additions
- add `getSubscriptionsByType` function
  - first argument `type` (required), second `cursor` (optional)
  - closes #17 
- add `getSubscriptionsByStatus` function
  - first argument `status` (required), second `cursor` (optional)
  - closes #17 
- added new 'private' function `_getSubs` to consolidate code related to the above additions

## Changes
- events now fire with the object as the argument passed to handlers
  - **this is a breaking change**
  - done because it is [not guaranteed](https://discuss.dev.twitch.tv/t/eventsub-api-documentation-inconsistency/29900/3) that keys in the JSON will be the same every time
  - will make TESjs more resilient to change in the future 
  - closes #18 
- update `getSubscriptions` to utilize `_getSubs` 'private' function
- update `getSubscription` when using type/condition to use `getSubscriptionsByType` for efficiency
- doc changes
  - updated functions doc for new functions
  - updated events doc for handler changes
  - updated events doc for clarification related to #16 
  - updated README for handler changes
  - updated README and functions doc to fix inconsistency outlined in #19 
    - closes #19 
  
## Testing
Updated test cases for event handlers.  Also ran through some black-box testing for the new functions and did not see any glaring issues.