### PR TITLE
Add Optional Argument to Event Callbacks, Doc Updates

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -22,6 +22,14 @@ tes.on('channel.update', event => {
 });
 ```
 
+## Getting Subscription Data
+When an event is fired, TESjs will also include subscription information as an optional second argument to your callback.  This second argument will be the subscription object of the EventSub payload as described in the [Twitch Doc](https://dev.twitch.tv/docs/eventsub#receive-a-notification).
+```js
+tes.on('channel.update', (event, subscription) => {
+  console.log(`Channel Update event for subscription with id ${subscription.id}`);
+});
+```
+
 ## Event Types
 Event type names can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types).  Events and their respective parameters can be found in the Twitch EventSub documentation [here](https://dev.twitch.tv/docs/eventsub/eventsub-reference#events).
 
@@ -33,7 +41,7 @@ tes.on('channel.ban', event => {
 ```
 
 ## Subscription Revocation
-According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.
+According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.  
 **NOTE:** As this 'event' is fired when a currently subscribed event topic is revoked, no explicit subscription is needed for this event.
 ```js
 tes.on('revocation', subscriptionData => {

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -62,7 +62,7 @@ Use the optional cursor argument to get a specific page of results
 ```js
 let subsArray = []
 //define a recursive function to get ALL subscriptions
-const getAll = (finishedCallback, cursor) => {
+const getAll = (callback, cursor) => {
   tes.getSubscriptions(cursor).then(data => {
     subsArray = subsArray.concat(data.data);
     if (data.pagination.cursor)
@@ -87,7 +87,7 @@ Use the optional cursor argument to get a specific page of results
 ```js
 let subsArray = []
 //define a recursive function to get ALL subscriptions
-const getAll = (finishedCallback, cursor) => {
+const getAll = (callback, cursor) => {
   tes.getSubscriptionsByType('channel.update', cursor).then(data => {
     subsArray = subsArray.concat(data.data);
     if (data.pagination.cursor)
@@ -112,7 +112,7 @@ Use the optional cursor argument to get a specific page of results
 ```js
 let subsArray = []
 //define a recursive function to get ALL subscriptions
-const getAll = (finishedCallback, cursor) => {
+const getAll = (callback, cursor) => {
   tes.getSubscriptionsByStatus('enabled', cursor).then(data => {
     subsArray = subsArray.concat(data.data);
     if (data.pagination.cursor)

--- a/lib/events.js
+++ b/lib/events.js
@@ -11,13 +11,13 @@ class EventManager {
         this._events = this._events || {};
     }
 
-    fire(type, data) {
-        const handler = this._events[type];
+    fire(sub, data) {
+        const handler = this._events[sub.type];
         if (!handler) {
-            logger.warn(`Recieved event for unhandled type: ${type}`);
+            logger.warn(`Recieved event for unhandled type: ${sub.type}`);
             return false;
         } else {
-            handler.call(this, data);
+            handler.call(this, data, sub);
             return true;
         }
     }

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -68,13 +68,13 @@ module.exports = function(server, secret, config) {
                             logger.log(`Received notification for type ${req.body.subscription.type}`);
                             recentMessageIds[messageId] = true;
                             setTimeout(_ => {delete recentMessageIds[messageId]}, 601000);
-                            EventManager.fire(req.body.subscription.type, req.body.event);
+                            EventManager.fire(req.body.subscription, req.body.event);
                             break;
                         case 'revocation':
                             logger.log(`Received revocation notification for subscription id ${req.body.subscription.id}`);
                             recentMessageIds[messageId] = true;
                             setTimeout(_ => {delete recentMessageIds[messageId]}, 601000);
-                            EventManager.fire('revocation', req.body.subscription);
+                            EventManager.fire({...req.body.subscription, type: 'revocation'}, req.body.subscription);
                             break;
                         default:
                             logger.log(`Received request with unhandled message type ${req.headers['twitch-eventsub-message-type']}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/events.js
+++ b/test/events.js
@@ -58,7 +58,7 @@ describe('EventManager', _ => {
             arg1Actual = event.arg1;
             arg2Actual = event.arg2;
         });
-        EventManager.fire('test', argData).should.eq(true);
+        EventManager.fire({type: 'test'}, argData).should.eq(true);
         arg1Actual.should.eq('test arg1');
         arg2Actual.should.eq('test arg2');
         done();
@@ -70,7 +70,7 @@ describe('EventManager', _ => {
             arg1: 'test arg1',
             arg2: 'test arg2'
         }
-        EventManager.fire('test', argData).should.eq(false);
+        EventManager.fire({type: 'test'}, argData).should.eq(false);
         done();
     });
 })


### PR DESCRIPTION
# Description
Minor changes to add a new optional argument to event callbacks.  This is a non-breaking change.  Update doc to reflect this, also fixing some typos.

## Changes
- callbacks passed to event handlers now have a second optional argument, `subscription`
  - contains the information specific to the subscription the event originated from
  - non-breaking change
  - closes #21
- update test cases/doc for above change
- update doc to fix variable name typo
  - closes #22 
  
## Testing
Updated test cases to correctly handle updated functionality.  Tested that subscription data was correctly passed in my blackbox env.
