### PR TITLE
#26/#27: Resolve After Handshake, More Robust Middleware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Contributions to the TESjs project are more than welcome!
 ## Commits
 When making a commit, it makes it easier to have a defined message structure.  Try to include the scope with a concise but descriptive message about the change.
 
-For example, if you made a new util function make your commit like so: `<utils>: added newUtil function`
+For example, if you made a new util function make your commit like so: `added newUtil function`
 
-If your commit is in relation to an issue, reference the issue number in your commit message as well: `#42 <utils>: add newUtil function`
+If your commit is in relation to an issue, reference the issue number in your commit message as well: `#42: add newUtil function`
 
 ## Pull Requests
 When making a [PR](https://github.com/mitchwadair/tesjs/compare), make sure to be very descriptive about the change you made and how it works.  Provide any details needed in order to test that your change works.

--- a/doc/express_integration.md
+++ b/doc/express_integration.md
@@ -42,7 +42,7 @@ const express = require('express');
 const myMiddleware = require('my-middleware'); //a fake middleware for example
 const TES = require('tesjs');
 
-// Create an Express app which uses the express.json() middleware
+// Create an Express app which uses the myMiddleware middleware
 const app = express()
 app.use(TES.ignoreInMiddleware(myMiddleware)); //pass the middleware you want to ignore TESjs to the TES.ignoreInMiddleware middleware
 app.get('/', (req, res) => {

--- a/doc/express_integration.md
+++ b/doc/express_integration.md
@@ -36,42 +36,15 @@ const tes = new TES(config);
 ```
 
 ## Middleware Conflicts
-In some cases, especially in more complex Express apps, you may be using some middlewares that conflict with TESjs.  This will happen if you are using a middleware through the `app.use` method, but not if you are using the middleware on individual routes.  An example of this may look as follows:
+In some cases, especially in more complex Express apps, you may be using some middlewares that conflict with TESjs.  This will happen if you are using a middleware through the `app.use` method, but not if you are using the middleware on individual routes.  To mitigate this problem, TESjs includes a middleware that you can use to ignore TESjs in other middlewares.  This middleware is called `ignoreInMiddleware` and is included in the TES object.  Modifying your Express app to use this would make your app look like this:
 ```js
 const express = require('express');
+const myMiddleware = require('my-middleware'); //a fake middleware for example
 const TES = require('tesjs');
 
 // Create an Express app which uses the express.json() middleware
 const app = express()
-app.use(express.json());
-app.get('/', (req, res) => {
-    res.send('OK');
-});
-app.listen(8080);
-
-// TESjs configuration passing the Express app as the listener's server
-const config = {
-  identity: {
-    id: process.env.CLIENT_ID,
-    secret: process.env.CLIENT_SECRET,
-  },
-  listener: {
-    baseURL: 'https://example.com',
-    server: app,
-  }
-}
-
-// Initialize TESjs with the config object
-const tes = new TES(config);
-```
-This will cause conflict with TESjs because `express.json()` modifies the contents of the `req` object before reaching the TESjs middleware which also modifies it.  To mitigate this problem, TESjs includes a middleware that you can use to ignore TESjs in other middlewares.  This middleware is called `ignoreInMiddleware` and is included in the TES object.  Modifying your Express app to use this would make your app look like this:
-```js
-const express = require('express');
-const TES = require('tesjs');
-
-// Create an Express app which uses the express.json() middleware
-const app = express()
-app.use(TES.ignoreInMiddleware(express.json())); //pass the middleware you want to ignore TESjs to the TES.ignoreInMiddleware middleware
+app.use(TES.ignoreInMiddleware(myMiddleware)); //pass the middleware you want to ignore TESjs to the TES.ignoreInMiddleware middleware
 app.get('/', (req, res) => {
     res.send('OK');
 });
@@ -96,6 +69,5 @@ With this change made, your Express app will still function normally and not cau
 
 ### Middlewares Known to Cause Conflict
 If you use any of these middlewares in your Express app, you will have to use `ignoreInMiddleware` to eliminate conflicts.  
-*If you find a middleware that is not on this list, feel free to put a PR in to keep the list up to date!*
-- [express.json()](https://expressjs.com/en/api.html#express.json)
-- [bodyParser.json()](http://expressjs.com/en/resources/middleware/body-parser.html#bodyparserjsonoptions)
+*If you find a middleware that is not on this list, feel free to put a PR in to keep the list up to date!*  
+- No known middlewares cause conflict at this time

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -133,7 +133,7 @@ const condition = {
 }
 tes.subscribe('channel.update', condition)
 ```
-Optionally, you can do something once the subscription has been made, and catch any errors
+Optionally, you can do something once the subscription has been made, and catch any errors.  The subscription promise will resolve after the handshake with Twitch is complete.  If the handshake times out for whatever reason, the promise will reject with the subscriptionID for any needed cleanup.
 ```js
 const condition = {
   broadcaster_user_id: '1337'
@@ -143,6 +143,15 @@ tes.subscribe('channel.update', condition)
   console.log('subscription has been created');
 })
 .catch(err => {
+  if (err.subscriptionID) {
+    // perform any cleanup needed
+    /* 
+      if the subscriptionID is present, the subscription was made but an error occurred when verifying it
+      this means that you will need to unsubscribe from that subscription to clean it up.
+    */
+    tes.unsubscribe(err.subscriptionID);
+  }
+  // if err.subscriptionID is not present, an error occurred with the request to Twitch
   console.log(err);
 });
 ```

--- a/lib/events.js
+++ b/lib/events.js
@@ -9,6 +9,7 @@ class EventManager {
     constructor() {
         EventManager._instance = this;
         this._events = this._events || {};
+        this._subscriptionQueue = this._subscriptionQueue || {};
     }
 
     fire(sub, data) {
@@ -39,6 +40,29 @@ class EventManager {
 
     removeAllListeners() {
         this._events = {};
+        return this;
+    }
+
+    queueSubscription(data, resolve, reject) {
+        this._subscriptionQueue[data.data[0].id] = {
+            data,
+            resolve,
+            timeout: setTimeout(_ => {
+                reject({
+                    message: 'Subscription verification timed out, this will need to be cleaned up',
+                    subscriptionID: data.data[0].id
+                });
+                delete this._subscriptionQueue[data.data[0].id];
+            }, 600000)
+        }
+        return this;
+    }
+
+    resolveSubscription(id) {
+        const {resolve, timeout, data} = this._subscriptionQueue[id];
+        clearTimeout(timeout);
+        resolve(data);
+        delete this._subscriptionQueue[id];
         return this;
     }
 }

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -142,7 +142,8 @@ class TES {
                     }
                 }
                 request('POST', 'https://api.twitch.tv/helix/eventsub/subscriptions', headers, body).then(data => {
-                    resolve(data);
+                    EventManager.queueSubscription(data, resolve, reject);
+                    //resolve(data);
                 }).catch(err => {
                     if (err.status === 409) {
                         this.getSubscription(type, condition).then(res => {

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -8,6 +8,18 @@ const crypto = require('crypto');
 const EventManager = require('./events');
 const logger = require('./logger');
 
+// correct req.body to be a JSON object if the parent app is using a different parsing middleware at the app level
+const correctBody = (req, res, next) => {
+    if (Buffer.isBuffer(req.body)) {
+        logger.debug('Convert body from raw');
+        req.body = JSON.parse(Buffer.toString(req.body)); //if app is using express.raw(), convert body to JSON
+    } else if (typeof req.body === 'string') {
+        logger.debug('Convert body from string');
+        req.body = JSON.parse(decodeURIComponent(req.body)); //if app is using express.urlencoded() or express.text(), convert body to JSON
+    }
+    next();
+}
+
 const verify = secret => {
     return (req, res, next) => {
         // thanks to https://github.com/BarryCarlyon/twitch_misc/blob/master/eventsub/handlers/nodejs/receive.js for the example
@@ -36,7 +48,7 @@ module.exports = function(server, secret, config) {
     const whserver = server || express();
     let recentMessageIds = {};
 
-    whserver.post('/teswh/event', express.json(), verify(secret), (req, res) => {
+    whserver.post('/teswh/event', express.json(), correctBody, verify(secret), (req, res) => {
         // check if our middleware detected a request from Twitch
         if (req.twitch_hub) {
             if (req.twitch_signature == req.calculated_signature) {

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -4,28 +4,31 @@
 // https://opensource.org/licenses/MIT
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const crypto = require('crypto');
 const EventManager = require('./events');
 const logger = require('./logger');
 
-const verify = (secret, req, res, buf, encoding) => {
-    // thanks to https://github.com/BarryCarlyon/twitch_misc/blob/master/eventsub/handlers/nodejs/receive.js for the example
-    // is there a hub to verify against
-    logger.debug('Verifying webhook request');
-    req.twitch_hub = false;
-    if (req.headers && req.headers.hasOwnProperty('twitch-eventsub-message-signature')) {
-        logger.debug('Request contains message signature, calculating verification signature')
-        req.twitch_hub = true;
-        
-        const id = req.headers['twitch-eventsub-message-id'];
-        const timestamp = req.headers['twitch-eventsub-message-timestamp'];
-        const signature = req.headers['twitch-eventsub-message-signature'].split('=');
+const verify = secret => {
+    return (req, res, next) => {
+        // thanks to https://github.com/BarryCarlyon/twitch_misc/blob/master/eventsub/handlers/nodejs/receive.js for the example
+        // is there a hub to verify against
+        logger.debug('Verifying webhook request');
+        req.twitch_hub = false;
+        if (req.headers && req.headers.hasOwnProperty('twitch-eventsub-message-signature')) {
+            logger.debug('Request contains message signature, calculating verification signature')
+            req.twitch_hub = true;
+            
+            const id = req.headers['twitch-eventsub-message-id'];
+            const timestamp = req.headers['twitch-eventsub-message-timestamp'];
+            const signature = req.headers['twitch-eventsub-message-signature'].split('=');
 
-        req.calculated_signature = crypto.createHmac(signature[0], secret)
-            .update(id + timestamp + buf)
-            .digest('hex');
-        req.twitch_signature = signature[1];
+            const buf = Buffer.from(JSON.stringify(req.body));
+            req.calculated_signature = crypto.createHmac(signature[0], secret)
+                .update(id + timestamp + buf)
+                .digest('hex');
+            req.twitch_signature = signature[1];
+        }
+        next();
     }
 }
 
@@ -33,7 +36,7 @@ module.exports = function(server, secret, config) {
     const whserver = server || express();
     let recentMessageIds = {};
 
-    whserver.post('/teswh/event', bodyParser.json({verify: (req, res, buf, encoding) => {verify(secret, req, res, buf, encoding)}}), (req, res) => {
+    whserver.post('/teswh/event', express.json(), verify(secret), (req, res) => {
         // check if our middleware detected a request from Twitch
         if (req.twitch_hub) {
             if (req.twitch_signature == req.calculated_signature) {

--- a/lib/whserver.js
+++ b/lib/whserver.js
@@ -57,6 +57,7 @@ module.exports = function(server, secret, config) {
                 if (req.body.hasOwnProperty('challenge') && req.headers['twitch-eventsub-message-type'] === 'webhook_callback_verification') {
                     logger.log(`Received challenge for ${req.body.subscription.type}, ${req.body.subscription.id}. Returning challenge.`)
                     res.status(200).type('text/plain').send(encodeURIComponent(req.body.challenge)); //ensure plain string response
+                    EventManager.resolveSubscription(req.body.subscription.id);
                     return;
                 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "^1.19.0",
         "express": "^4.17.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://www.tesjs.net",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description
This PR fixes an issue where there was a reliance on `bodyParser.json()` being called as a middleware, and requiring the use of `TES.ignoreInMiddleware()` if an existing app is already using `bodyParser`.  It also changes the resolve state of the promise returned by `subscribe` to after the verification handshake completes.

## Additions
- Timeout subscription call after 10 minutes without resolve
  - only for successful calls to the Twitch API
  - error will have `subscriptionID` field if developer needs

## Changes
- `whserver` middleware more robust
  - remove `bodyParser` dependency in favor of `express.json()` as it was deprecated
  - ensures correct formatting of request body even if already formatted
  - creates buffer from body rather than using the verify option in json middleware
  - updated doc accordingly
  - closes #27
- promise returned by TES.subscribe() resolves after verification handshake
  - ensures the developer knows the subscription and verification is successful'
  - timeout after 10 minutes
    - error provides subscriptionID so developer can clean up subscription as needed
  - updated doc accordingly
  - closes #26 
  
## Testing
All test cases still working, ensured new functionality worked in black box environment
