### PR TITLE
handle test error case

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -59,6 +59,7 @@ class EventManager {
     }
 
     resolveSubscription(id) {
+        if (!this._subscriptionQueue[id]) return this;
         const {resolve, timeout, data} = this._subscriptionQueue[id];
         clearTimeout(timeout);
         resolve(data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description
Handles a case that is unique to the test suite where resolving a queued subscription would spit an error.  This is because the queue is not populated for the test, as no subscription is actually being made (it is posting to the wh endpoint with dummy data).  

## Changes
- adds a check to see if a queued subscription exists,
  - if it doesn't just return
  
## Testing
Tests continue to pass but without the error now.
