### PR TITLE
#34: Update to Separate Client and Webhooks Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ const tes = new TES({
         secret: YOUR_CLIENT_SECRET //do not ship this in plaintext!! use environment variables so this does not get exposed
     },
     listener: {
-        baseURL: "https://example.com"
+        baseURL: "https://example.com",
+        secret: process.env.WEBHOOKS_SECRET,
     }
 });
 
@@ -76,6 +77,7 @@ const tes = new TES({
     },
     listener: {
         baseURL: "https://example.com",
+        secret: process.env.WEBHOOKS_SECRET,
         server: app
     }
 });

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -12,11 +12,12 @@ The configuration object is required as an argument when creating the TESjs inst
 
 `identity`: (Required) Set up your client's identity
 - `id`: *string* - (Required) your app's client id
-- `secret`: *string* - (Required) your app's secret (make sure this is not in plaintext, use environment variables for this)
+- `secret`: *string* - (Required) your app's client secret (make sure this is not in plaintext, use environment variables for this)
 
 `listener`: (Required) Setting your notification listener details
 - `baseURL`: *string* - (Required) the url where your endpoint is hosted
   - See [Twitch doc](https://dev.twitch.tv/docs/eventsub) for details on local development
+- `secret`: *string* - (Required) the secret to use for your webhooks subscriptions (make sure this is not in plaintext, use environment variables for this)
 - `port`: *number* - (Optional) the port to listen at.
   - defaults to process.env.PORT or 8080
   - Keep in mind, this is the port of the Express http server, not your https endpoint (served at `baseURL`) which should have port 443
@@ -39,6 +40,7 @@ const config = {
   },
   listener: {
     baseURL: 'https://example.com',
+    secret: process.env.WEBHOOKS_SECRET,
   }
 }
 
@@ -56,6 +58,7 @@ const config = {
   },
   listener: {
     baseURL: 'https://example.com',
+    secret: process.env.WEBHOOKS_SECRET,
     port: 8081,
   }
 }
@@ -81,6 +84,7 @@ const config = {
   },
   listener: {
     baseURL: 'https://example.com',
+    secret: process.env.WEBHOOKS_SECRET,
     server: app,
   }
 }

--- a/doc/events.md
+++ b/doc/events.md
@@ -12,7 +12,8 @@ const tes = new TES({
         secret: CLIENT_SECRET
     },
     listener: {
-        baseURL: "https://example.com"
+        baseURL: "https://example.com",
+        secret: process.env.WEBHOOKS_SECRET,
     }
 });
 

--- a/doc/express_integration.md
+++ b/doc/express_integration.md
@@ -27,6 +27,7 @@ const config = {
   },
   listener: {
     baseURL: 'https://example.com',
+    secret: process.env.WEBHOOKS_SECRET,
     server: app,
   }
 }
@@ -58,6 +59,7 @@ const config = {
   },
   listener: {
     baseURL: 'https://example.com',
+    secret: process.env.WEBHOOKS_SECRET,
     server: app,
   }
 }

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -26,7 +26,8 @@ const tes = new TES({
         secret: CLIENT_SECRET
     },
     listener: {
-        baseURL: "https://example.com"
+        baseURL: "https://example.com",
+        secret: process.env.WEBHOOKS_SECRET,
     }
 });
 ```

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -32,12 +32,13 @@ class TES {
         this.clientSecret = config.identity.secret;
 
         this.baseURL = config.listener.baseURL;
+        this.whSecret = config.listener.secret;
         this.port = config.listener.port || process.env.PORT || 8080;
         const serverConfig = {
             ignoreDuplicateMessages: config.listener.ignoreDuplicateMessages === false ? false : true,
             ignoreOldMessages: config.listener.ignoreOldMessages === false ? false : true
         }
-        this.whserver = whserver(config.listener.server, this.clientSecret, serverConfig);
+        this.whserver = whserver(config.listener.server, this.whSecret, serverConfig);
         this._whserverlistener = config.listener.server ? null : this.whserver.listen(this.port);
 
         config.options.debug && logger.setLevel('debug');
@@ -137,7 +138,7 @@ class TES {
                     transport: {
                         method: 'webhook',
                         callback: `${this.baseURL}/teswh/event`,
-                        secret: this.clientSecret
+                        secret: this.whSecret
                     }
                 }
                 request('POST', 'https://api.twitch.tv/helix/eventsub/subscriptions', headers, body).then(data => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tesjs",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -6,6 +6,7 @@ const crypto = require('crypto');
 // example data taken from https://dev.twitch.tv/docs/eventsub examples
 
 const secret = 's3cRe7';
+const whSecret = 's3cRe7tW0';
 const timestamp = new Date().toISOString();
 const tes = new TES({
     identity: {
@@ -13,7 +14,8 @@ const tes = new TES({
         secret: secret
     },
     listener: {
-        baseURL: 'localhost'
+        baseURL: 'localhost',
+        secret: whSecret
     }
 });
 const app = tes.whserver;
@@ -60,7 +62,7 @@ describe('whserver', _ => {
                 "created_at": "2019-11-16T10:11:12.123Z"
             }
         }
-        const signature = crypto.createHmac('sha256', secret)
+        const signature = crypto.createHmac('sha256', whSecret)
             .update('e76c6bd4-55c9-4987-8304-da1588d8988b' + timestamp + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)
@@ -109,7 +111,7 @@ describe('whserver', _ => {
                 "broadcaster_user_name":   "twitch"
             }
         }
-        const signature = crypto.createHmac('sha256', secret)
+        const signature = crypto.createHmac('sha256', whSecret)
             .update('befa7b53-d79d-478f-86b9-120f112b044e' + timestamp + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)
@@ -157,7 +159,7 @@ describe('whserver', _ => {
             "total": 1,
             "pagination": {}
         }
-        const signature = crypto.createHmac('sha256', secret)
+        const signature = crypto.createHmac('sha256', whSecret)
             .update('84c1e79a-2a4b-4c13-ba0b-4312293e9308' + timestamp + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)
@@ -207,7 +209,7 @@ describe('whserver', _ => {
                 "broadcaster_user_name":   "twitch"
             }
         }
-        const signature = crypto.createHmac('sha256', secret)
+        const signature = crypto.createHmac('sha256', whSecret)
             .update('befa7b53-d79d-478f-86b9-120f112b044e' + timestamp + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)
@@ -258,7 +260,7 @@ describe('whserver', _ => {
             }
         }
         const oldTime = new Date(Date.now() - 601000).toISOString()
-        const signature = crypto.createHmac('sha256', secret)
+        const signature = crypto.createHmac('sha256', whSecret)
             .update('befa7b53-d79d-478f-86b9-120f112b044d' + oldTime + Buffer.from(JSON.stringify(payload), 'utf-8'))
             .digest('hex');
         request(app)


### PR DESCRIPTION
# Description
According to the doc, you should not use your Client Secret as the secret for your EventSub subscriptions. This needed to be changed.

## Changes
- there are now two separate options for secrets in config
  - `identity.secret` and `listener.secret`
  
## Testing
Updated unit tests, all passing.  Blackbox tested to verify functionality as well.
