### PR TITLE
#36: Use Twitch CLI in Test Where Possible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: brew install twitchdev/twitch/twitch-cli
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/doc/events.md
+++ b/doc/events.md
@@ -42,7 +42,7 @@ tes.on('channel.ban', event => {
 ```
 
 ## Subscription Revocation
-According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub#subscription-revocation), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.  
+According to the [Twitch Documentation](https://dev.twitch.tv/docs/eventsub/handling-webhook-events#revoking-your-subscription), a subscription can be revoked at any time for various reasons.  There may be cases where you want to perform some cleanup based on which subscription got revoked.  You can do this by creating a handler for subscription revocation.  
 **NOTE:** As this 'event' is fired when a currently subscribed event topic is revoked, no explicit subscription is needed for this event.
 ```js
 tes.on('revocation', subscriptionData => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "chai": "4.3.6",
         "mocha": "10.0.0",
+        "nock": "13.2.9",
         "sinon": "14.0.0",
         "supertest": "6.2.3"
       }
@@ -1011,6 +1012,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -1031,6 +1038,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -1276,6 +1289,44 @@
         "isarray": "0.0.1"
       }
     },
+    "node_modules/nock": {
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -1412,6 +1463,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -2774,6 +2834,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -2788,6 +2854,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2978,6 +3050,35 @@
         }
       }
     },
+    "nock": {
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -3064,6 +3165,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "mocha --exit"
+    "test": "mocha ./test/tests.js --bail --exit"
   },
   "author": "Mitchell Adair (https://github.com/mitchwadair)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "chai": "4.3.6",
     "mocha": "10.0.0",
+    "nock": "13.2.9",
     "sinon": "14.0.0",
     "supertest": "6.2.3"
   }

--- a/test/events.js
+++ b/test/events.js
@@ -1,76 +1,76 @@
-const EventManager = require('../lib/events');
-const should = require('chai').should();
+const { expect } = require("chai");
+const EventManager = require("../lib/events");
 
-beforeEach(done => {
+beforeEach(async () => {
     EventManager.removeAllListeners();
-    done();
 });
 
-describe('EventManager', _ => {
-    it('should not add a listener which is passed a non-function handler', done => {
-        should.not.exist(EventManager._events['test']);
-        EventManager.addListener.bind('test', 'not a function').should.throw(Error);
-        done();
+describe("EventManager", () => {
+    it("should not add a listener which is passed a non-function handler", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        EventManager.addListener.bind("test", "not a function").should.throw(Error);
     });
 
-    it('adds new event listeners', done => {
-        should.not.exist(EventManager._events['test']);
-        EventManager.addListener('test', _ => {return});
-        EventManager._events['test'].should.be.a('function');
-        done();
-    });
-
-    it('removes individual listeners correctly', done => {
-        should.not.exist(EventManager._events['test']);
-        EventManager.addListener('test', _ => {return});
-        EventManager._events['test'].should.be.a('function');
-        EventManager.removeListener('test');
-        should.not.exist(EventManager._events['test']);
-        done();
-    });
-
-    it('does nothing when removing invalid listener', done => {
-        should.not.exist(EventManager._events['test']);
-        EventManager.removeListener('test');
-        should.not.exist(EventManager._events['test']);
-        done();
-    })
-
-    it('removes all listeners correctly', done => {
-        should.not.exist(EventManager._events['test']);
-        EventManager.addListener('test', _ => {return});
-        EventManager.addListener('test2', _ => {return});
-        EventManager._events['test'].should.be.a('function');
-        EventManager._events['test2'].should.be.a('function');
-        EventManager.removeAllListeners();
-        EventManager._events.should.be.an('object').that.is.empty;
-        done();
-    });
-
-    it('fires existing events correctly with correct arguments', done => {
-        should.not.exist(EventManager._events['test']);
-        const argData = {
-            arg1: 'test arg1',
-            arg2: 'test arg2'
-        }
-        let arg1Actual, arg2Actual;
-        EventManager.addListener('test', event => {
-            arg1Actual = event.arg1;
-            arg2Actual = event.arg2;
+    it("adds new event listeners", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        EventManager.addListener("test", () => {
+            return;
         });
-        EventManager.fire({type: 'test'}, argData).should.eq(true);
-        arg1Actual.should.eq('test arg1');
-        arg2Actual.should.eq('test arg2');
-        done();
+        EventManager._events["test"].should.be.a("function");
     });
 
-    it('does not fire unknown events', done => {
-        should.not.exist(EventManager._events['test']);
-        const argData = {
-            arg1: 'test arg1',
-            arg2: 'test arg2'
-        }
-        EventManager.fire({type: 'test'}, argData).should.eq(false);
-        done();
+    it("removes individual listeners correctly", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        EventManager.addListener("test", () => {
+            return;
+        });
+        EventManager._events["test"].should.be.a("function");
+        EventManager.removeListener("test");
+        expect(EventManager._events["test"]).to.not.exist;
     });
-})
+
+    it("does nothing when removing invalid listener", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        EventManager.removeListener("test");
+        expect(EventManager._events["test"]).to.not.exist;
+    });
+
+    it("removes all listeners correctly", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        EventManager.addListener("test", () => {
+            return;
+        });
+        EventManager.addListener("test2", () => {
+            return;
+        });
+        EventManager._events["test"].should.be.a("function");
+        EventManager._events["test2"].should.be.a("function");
+        EventManager.removeAllListeners();
+        EventManager._events.should.be.an("object").that.is.empty;
+    });
+
+    it("fires existing events correctly with correct arguments", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        const argData = {
+            arg1: "test arg1",
+            arg2: "test arg2",
+        };
+        let arg1Actual, arg2Actual;
+        EventManager.addListener("test", ({ arg1, arg2 }) => {
+            arg1Actual = arg1;
+            arg2Actual = arg2;
+        });
+        EventManager.fire({ type: "test" }, argData).should.eq(true);
+        arg1Actual.should.eq("test arg1");
+        arg2Actual.should.eq("test arg2");
+    });
+
+    it("does not fire unknown events", async () => {
+        expect(EventManager._events["test"]).to.not.exist;
+        const argData = {
+            arg1: "test arg1",
+            arg2: "test arg2",
+        };
+        EventManager.fire({ type: "test" }, argData).should.eq(false);
+    });
+});

--- a/test/events.js
+++ b/test/events.js
@@ -8,7 +8,11 @@ beforeEach(async () => {
 describe("EventManager", () => {
     it("should not add a listener which is passed a non-function handler", async () => {
         expect(EventManager._events["test"]).to.not.exist;
-        EventManager.addListener.bind("test", "not a function").should.throw(Error);
+        try {
+            EventManager.addListener("test", "not a function");
+        } catch (error) {
+            expect(error.message).to.eq("Event handler must be a function");
+        }
     });
 
     it("adds new event listeners", async () => {
@@ -16,7 +20,8 @@ describe("EventManager", () => {
         EventManager.addListener("test", () => {
             return;
         });
-        EventManager._events["test"].should.be.a("function");
+        expect(EventManager._events["test"]).to.exist;
+        expect(typeof EventManager._events["test"]).to.eq("function");
     });
 
     it("removes individual listeners correctly", async () => {
@@ -24,7 +29,8 @@ describe("EventManager", () => {
         EventManager.addListener("test", () => {
             return;
         });
-        EventManager._events["test"].should.be.a("function");
+        expect(EventManager._events["test"]).to.exist;
+        expect(typeof EventManager._events["test"]).to.eq("function");
         EventManager.removeListener("test");
         expect(EventManager._events["test"]).to.not.exist;
     });
@@ -43,10 +49,12 @@ describe("EventManager", () => {
         EventManager.addListener("test2", () => {
             return;
         });
-        EventManager._events["test"].should.be.a("function");
-        EventManager._events["test2"].should.be.a("function");
+        expect(EventManager._events["test"]).to.exist;
+        expect(typeof EventManager._events["test"]).to.eq("function");
+        expect(EventManager._events["test2"]).to.exist;
+        expect(typeof EventManager._events["test2"]).to.eq("function");
         EventManager.removeAllListeners();
-        EventManager._events.should.be.an("object").that.is.empty;
+        expect(EventManager._events).to.be.empty;
     });
 
     it("fires existing events correctly with correct arguments", async () => {
@@ -60,9 +68,9 @@ describe("EventManager", () => {
             arg1Actual = arg1;
             arg2Actual = arg2;
         });
-        EventManager.fire({ type: "test" }, argData).should.eq(true);
-        arg1Actual.should.eq("test arg1");
-        arg2Actual.should.eq("test arg2");
+        expect(EventManager.fire({ type: "test" }, argData)).to.eq(true);
+        expect(arg1Actual).to.eq("test arg1");
+        expect(arg2Actual).to.eq("test arg2");
     });
 
     it("does not fire unknown events", async () => {
@@ -71,6 +79,6 @@ describe("EventManager", () => {
             arg1: "test arg1",
             arg2: "test arg2",
         };
-        EventManager.fire({ type: "test" }, argData).should.eq(false);
+        expect(EventManager.fire({ type: "test" }, argData)).to.eq(false);
     });
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,66 +1,59 @@
-const logger = require('../lib/logger');
-const sinon = require('sinon');
+const logger = require("../lib/logger");
+const sinon = require("sinon");
 
-describe('logger', _ => {
-    let spy;
+describe("logger", () => {
+    let stub;
 
-    beforeEach(done => {
-        spy = sinon.spy(console, 'log');
-        done();
+    beforeEach(async () => {
+        stub = sinon.stub(console, "log");
     });
-    afterEach(done => {
-        console.log.restore();
-        logger.setLevel('none');
-        done();
+    afterEach(async () => {
+        stub.restore();
+        logger.setLevel("none");
     });
 
-    it('should not log anything at none level', done => {
-        logger.setLevel('none');
-        logger.log('this is an info log');
-        logger.warn('this is a warn log');
-        logger.error('this is an error log');
-        logger.debug('this is a debug log');
-        sinon.assert.notCalled(spy);
-        done();
+    it("should not log anything at none level", async () => {
+        logger.setLevel("none");
+        logger.log("this is an info log");
+        logger.warn("this is a warn log");
+        logger.error("this is an error log");
+        logger.debug("this is a debug log");
+        sinon.assert.notCalled(stub);
     });
 
-    it('should only log info at info level', done => {
-        logger.setLevel('info');
-        logger.log('this is an info log');
-        logger.warn('this is a warn log');
-        logger.error('this is an error log');
-        logger.debug('this is a debug log');
-        sinon.assert.calledOnce(spy);
-        done();
+    it("should only log info at info level", async () => {
+        logger.setLevel("info");
+        logger.log("this is an info log");
+        logger.warn("this is a warn log");
+        logger.error("this is an error log");
+        logger.debug("this is a debug log");
+        sinon.assert.calledOnce(stub);
     });
 
-    it('should only log info and warn at warn level', done => {
-        logger.setLevel('warn');
-        logger.log('this is an info log');
-        logger.warn('this is a warn log');
-        logger.error('this is an error log');
-        logger.debug('this is a debug log');
-        sinon.assert.calledTwice(spy);
-        done();
+    it("should only log info and warn at warn level", async () => {
+        logger.setLevel("warn");
+        logger.log("this is an info log");
+        logger.warn("this is a warn log");
+        logger.error("this is an error log");
+        logger.debug("this is a debug log");
+        sinon.assert.calledTwice(stub);
     });
 
-    it('should only log info, warn and error at error level', done => {
-        logger.setLevel('error');
-        logger.log('this is an info log');
-        logger.warn('this is a warn log');
-        logger.error('this is an error log');
-        logger.debug('this is a debug log');
-        sinon.assert.calledThrice(spy);
-        done();
+    it("should only log info, warn and error at error level", async () => {
+        logger.setLevel("error");
+        logger.log("this is an info log");
+        logger.warn("this is a warn log");
+        logger.error("this is an error log");
+        logger.debug("this is a debug log");
+        sinon.assert.calledThrice(stub);
     });
 
-    it('should log all levels at debug level', done => {
-        logger.setLevel('debug');
-        logger.log('this is an info log');
-        logger.warn('this is a warn log');
-        logger.error('this is an error log');
-        logger.debug('this is a debug log');
-        sinon.assert.callCount(spy, 4);
-        done();
+    it("should log all levels at debug level", async () => {
+        logger.setLevel("debug");
+        logger.log("this is an info log");
+        logger.warn("this is a warn log");
+        logger.error("this is an error log");
+        logger.debug("this is a debug log");
+        sinon.assert.callCount(stub, 4);
     });
-})
+});

--- a/test/tes.js
+++ b/test/tes.js
@@ -72,7 +72,7 @@ describe("TES", () => {
         const tes = tryInitTES(configValid);
         setTimeout(() => {
             tes._whserverlistener.close();
-            tes.should.be.an.instanceof(TES);
+            expect(tes).to.be.an.instanceOf(TES);
             done();
         }, 100);
     });

--- a/test/testUtil.js
+++ b/test/testUtil.js
@@ -1,3 +1,5 @@
+const { exec } = require("child_process");
+
 const buildObjectWithoutKey = (obj, key) => {
     const filteredEntries = Object.entries(obj).filter(([k]) => {
         return k !== key;
@@ -5,6 +7,19 @@ const buildObjectWithoutKey = (obj, key) => {
     return Object.fromEntries(filteredEntries);
 };
 
+const cmd = (command) => {
+    return new Promise((resolve, reject) => {
+        exec(command, (err, stdout, _stderr) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+};
+
 module.exports = {
     buildObjectWithoutKey,
+    cmd,
 };

--- a/test/test_environment.js
+++ b/test/test_environment.js
@@ -1,0 +1,13 @@
+const { expect } = require("chai");
+const { cmd } = require("./testUtil");
+
+describe("Test Environment", () => {
+    it("has the twitch CLI installed", async () => {
+        try {
+            const out = await cmd("twitch version");
+            expect(out).to.not.be.undefined;
+        } catch (err) {
+            throw new Error("Twitch CLI not installed");
+        }
+    });
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,6 @@
+require("./test_environment");
+require("./utils");
+require("./logger");
+require("./tes");
+require("./whserver");
+require("./events");

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,9 +1,9 @@
-const utils = require("../lib/utils");
-const should = require("chai").should();
+const { expect } = require("chai");
+const { objectShallowEquals } = require("../lib/utils");
 
-describe("utils", (_) => {
-    describe("objectShallowEquals()", (_) => {
-        it("should return true when two objects match", (done) => {
+describe("utils", () => {
+    describe("objectShallowEquals()", () => {
+        it("should return true when two objects match", async () => {
             const obj1 = {
                 k1: "key1",
                 k2: "key2",
@@ -12,11 +12,10 @@ describe("utils", (_) => {
                 k1: "key1",
                 k2: "key2",
             };
-            utils.objectShallowEquals(obj1, obj2).should.eq(true);
-            done();
+            expect(objectShallowEquals(obj1, obj2)).to.eq(true);
         });
 
-        it("should return false when second object keys dont match first object keys", (done) => {
+        it("should return false when second object keys dont match first object keys", async () => {
             const obj1 = {
                 k1: "key1",
                 k2: "key2",
@@ -24,11 +23,10 @@ describe("utils", (_) => {
             const obj2 = {
                 wrong: "different",
             };
-            utils.objectShallowEquals(obj1, obj2).should.eq(false);
-            done();
+            expect(objectShallowEquals(obj1, obj2)).to.eq(false);
         });
 
-        it("should return false when second object values dont match first object values", (done) => {
+        it("should return false when second object values dont match first object values", async () => {
             const obj1 = {
                 k1: "key1",
                 k2: "key2",
@@ -37,11 +35,10 @@ describe("utils", (_) => {
                 k1: "not key1",
                 k2: "not key2",
             };
-            utils.objectShallowEquals(obj1, obj2).should.eq(false);
-            done();
+            expect(objectShallowEquals(obj1, obj2)).to.eq(false);
         });
 
-        it("should return false when second object has extra keys", (done) => {
+        it("should return false when second object has extra keys", async () => {
             const obj1 = {
                 k1: "key1",
                 k2: "key2",
@@ -51,8 +48,7 @@ describe("utils", (_) => {
                 k2: "key2",
                 k3: "new key",
             };
-            utils.objectShallowEquals(obj1, obj2).should.eq(false);
-            done();
+            expect(objectShallowEquals(obj1, obj2)).to.eq(false);
         });
     });
 });

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -16,7 +16,7 @@ const REDIRECT_URL = "http://localhost:8080/teswh/event";
 
 describe("whserver", () => {
     let tes, app;
-    before((done) => {
+    before(() => {
         TES._instance = null;
         tes = new TES({
             identity: {
@@ -30,7 +30,6 @@ describe("whserver", () => {
             options: { logging: false },
         });
         app = tes.whserver;
-        setTimeout(done, 500);
     });
 
     it("responds with 401 to request without twitch message signature", (done) => {
@@ -51,7 +50,7 @@ describe("whserver", () => {
                     const out = await cmd(`twitch event verify channel.update -F ${REDIRECT_URL} -s ${whSecret}`);
                     expect(out).to.contain("Valid response");
                     done();
-                }, 100);
+                }, 10);
                 return {
                     data: [{ id: 1 }],
                 };

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -1,16 +1,22 @@
 const TES = require("../main");
 const request = require("supertest");
+const nock = require("nock");
+const sinon = require("sinon");
 const crypto = require("crypto");
+const { cmd } = require("./testUtil");
+const { expect } = require("chai");
 
 // example data taken from https://dev.twitch.tv/docs/eventsub examples
 
 const secret = "s3cRe7";
-const whSecret = "s3cRe7tW0";
+const whSecret = "s3cRe7tW0o";
 const timestamp = new Date().toISOString();
+
+const REDIRECT_URL = "http://localhost:8080/teswh/event";
 
 describe("whserver", () => {
     let tes, app;
-    before(() => {
+    before((done) => {
         TES._instance = null;
         tes = new TES({
             identity: {
@@ -21,123 +27,47 @@ describe("whserver", () => {
                 baseURL: "localhost",
                 secret: whSecret,
             },
+            options: { logging: false },
         });
         app = tes.whserver;
+        setTimeout(done, 500);
     });
 
     it("responds with 401 to request without twitch message signature", (done) => {
         request(app).post("/teswh/event").send({}).expect(401, done);
     });
 
-    it("responds with 403 to request with signature mismatch", (done) => {
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "e76c6bd4-55c9-4987-8304-da1588d8988b",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
-                "Twitch-Eventsub-Message-Signature": "sha256=thisiswrong",
-                "Twitch-Eventsub-Message-Timestamp": timestamp,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send({})
-            .expect(403, done);
+    it("responds with 403 to request with signature mismatch", async () => {
+        const out = await cmd(`twitch event trigger subscribe -F ${REDIRECT_URL} -s wrongsecret`);
+        expect(out).to.contain("Recieved Status Code: 403");
+        expect(out).to.contain("Request signature mismatch");
     });
 
     it("responds with challenge when challenged", (done) => {
-        const payload = {
-            challenge: "pogchamp-kappa-360noscope-vohiyo",
-            subscription: {
-                id: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
-                status: "webhook_callback_verification_pending",
-                type: "channel.follow",
-                version: "1",
-                condition: {
-                    broadcaster_user_id: "12826",
-                },
-                transport: {
-                    method: "webhook",
-                    callback: "https://example.com/webhooks/callback",
-                },
-                created_at: "2019-11-16T10:11:12.123Z",
-            },
-        };
-        const signature = crypto
-            .createHmac("sha256", whSecret)
-            .update("e76c6bd4-55c9-4987-8304-da1588d8988b" + timestamp + Buffer.from(JSON.stringify(payload), "utf-8"))
-            .digest("hex");
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "e76c6bd4-55c9-4987-8304-da1588d8988b",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
-                "Twitch-Eventsub-Message-Signature": `sha256=${signature}`,
-                "Twitch-Eventsub-Message-Timestamp": timestamp,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send(payload)
-            .expect(200)
-            .end((err, res) => {
-                if (err) return done(err);
-                res.text.should.eq("pogchamp-kappa-360noscope-vohiyo");
-                done();
+        nock("https://api.twitch.tv")
+            .post("/helix/eventsub/subscriptions")
+            .reply(201, () => {
+                setTimeout(async () => {
+                    const out = await cmd(`twitch event verify channel.update -F ${REDIRECT_URL} -s ${whSecret}`);
+                    expect(out).to.contain("Valid response");
+                    done();
+                }, 100);
+                return {
+                    data: [{ id: 1 }],
+                };
             });
+
+        tes.subscribe("channel.update", { broadcaster_user_id: "1234" });
     });
 
-    it("responds with 200 OK when receiving a notification and the event should be fired", (done) => {
-        let notificationRecieved = false;
-        tes.on("channel.follow", () => {
-            notificationRecieved = true;
-        });
-        const payload = {
-            subscription: {
-                id: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
-                type: "channel.follow",
-                version: "1",
-                condition: {
-                    broadcaster_user_id: "12826",
-                },
-                transport: {
-                    method: "webhook",
-                    callback: "https://example.com/webhooks/callback",
-                },
-                created_at: "2019-11-16T10:11:12.123Z",
-            },
-            event: {
-                user_id: "1337",
-                user_name: "awesome_user",
-                broadcaster_user_id: "12826",
-                broadcaster_user_name: "twitch",
-            },
-        };
-        const signature = crypto
-            .createHmac("sha256", whSecret)
-            .update("befa7b53-d79d-478f-86b9-120f112b044e" + timestamp + Buffer.from(JSON.stringify(payload), "utf-8"))
-            .digest("hex");
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "befa7b53-d79d-478f-86b9-120f112b044e",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "notification",
-                "Twitch-Eventsub-Message-Signature": `sha256=${signature}`,
-                "Twitch-Eventsub-Message-Timestamp": timestamp,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send(payload)
-            .expect(200)
-            .end((err, res) => {
-                if (err) return done(err);
-                res.text.should.eq("OK");
-                notificationRecieved.should.eq(true);
-                done();
-            });
+    it("responds with 200 OK when receiving a notification and the event should be fired", async () => {
+        const cb = sinon.spy();
+        tes.on("channel.follow", cb);
+        await cmd(`twitch event trigger channel.follow -F ${REDIRECT_URL} -s ${whSecret}`);
+        sinon.assert.called(cb);
     });
 
+    // TODO: update when able to send a revocation notification in Twitch CLI
     it("responds with 200 OK when receiving a revocation and the revocation event should be fired", (done) => {
         let notificationRecieved = false;
         tes.on("revocation", () => {
@@ -179,65 +109,28 @@ describe("whserver", () => {
             })
             .send(payload)
             .expect(200)
-            .end((err, res) => {
+            .end((err, { text }) => {
                 if (err) return done(err);
-                res.text.should.eq("OK");
-                notificationRecieved.should.eq(true);
+                expect(text).to.eq("OK");
+                expect(notificationRecieved).to.eq(true);
                 done();
             });
     });
 
-    it("responds with 200 OK when receiving a duplicate notification and the event should not be fired", (done) => {
-        let notificationRecieved = false;
-        tes.on("channel.follow", () => {
-            notificationRecieved = true;
-        });
-        const payload = {
-            subscription: {
-                id: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
-                type: "channel.follow",
-                version: "1",
-                condition: {
-                    broadcaster_user_id: "12826",
-                },
-                transport: {
-                    method: "webhook",
-                    callback: "https://example.com/webhooks/callback",
-                },
-                created_at: "2019-11-16T10:11:12.123Z",
-            },
-            event: {
-                user_id: "1337",
-                user_name: "awesome_user",
-                broadcaster_user_id: "12826",
-                broadcaster_user_name: "twitch",
-            },
+    it("responds with 200 OK when receiving a duplicate notification and the event should not be fired", async () => {
+        let resendID;
+        const cb = (_event, { id }) => {
+            resendID = id;
         };
-        const signature = crypto
-            .createHmac("sha256", whSecret)
-            .update("befa7b53-d79d-478f-86b9-120f112b044e" + timestamp + Buffer.from(JSON.stringify(payload), "utf-8"))
-            .digest("hex");
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "befa7b53-d79d-478f-86b9-120f112b044e",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "notification",
-                "Twitch-Eventsub-Message-Signature": `sha256=${signature}`,
-                "Twitch-Eventsub-Message-Timestamp": timestamp,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send(payload)
-            .expect(200)
-            .end((err, res) => {
-                if (err) return done(err);
-                res.text.should.eq("OK");
-                notificationRecieved.should.eq(false);
-                done();
-            });
+        const spy = sinon.spy(cb);
+        tes.on("channel.follow", spy);
+
+        await cmd(`twitch event trigger channel.follow -F ${REDIRECT_URL} -s ${whSecret}`);
+        await cmd(`twitch event retrigger channel.follow -F ${REDIRECT_URL} -s ${whSecret} -i ${resendID}`);
+        sinon.assert.calledOnce(spy);
     });
 
+    // TODO: update when able to set timestamps in Twitch CLI
     it("responds with 200 OK when receiving an old notification and the event should not be fired", (done) => {
         let notificationRecieved = false;
         tes.on("channel.follow", () => {
@@ -282,10 +175,10 @@ describe("whserver", () => {
             })
             .send(payload)
             .expect(200)
-            .end((err, res) => {
+            .end((err, { text }) => {
                 if (err) return done(err);
-                res.text.should.eq("OK");
-                notificationRecieved.should.eq(false);
+                expect(text).to.eq("OK");
+                expect(notificationRecieved).to.eq(false);
                 done();
             });
     });


### PR DESCRIPTION
# Description

This PR adds the [Twitch CLI](https://github.com/twitchdev/twitch-cli) as a peer dependency for testing, and uses it where possible for tests.  Also updated some other tests to be more correct/prettier.  Also update a doc link that was stale

## Additions
- [Twitch CLI](https://github.com/twitchdev/twitch-cli) is now a peer dependency
  - this makes tests more concise and ensures that data is accurate to how Twitch will supply it in production
  - added install step to test GH action for this
  - Closes #36 (although, some TODOs still present for missing CLI features)
- Added environment test

## Changes
- Clean up other tests
- Updated test suite structure
  - Tests now run in order imported in `tests.js`
- Update doc link for revocation
  
## Testing
Test suite is passing locally
