### PR TITLE
#47: External Auth Handling

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -13,6 +13,10 @@ The configuration object is required as an argument when creating the TESjs inst
 `identity`: (Required) Set up your client's identity
 - `id`: *string* - (Required) your app's client id
 - `secret`: *string* - (Required) your app's client secret (make sure this is not in plaintext, use environment variables for this)
+- `onAuthenticationFailure`: *function* - (Optional) if you already have an authentication solution for your app elsewhere use this to avoid token conflicts
+  - This function should return a Promise that resolves an app access token
+- `accessToken`: *string* (Optional) if you already have an app access token at the time of initing TESjs, you can pass it here
+  - This should usually be paired with `onAuthenticationFailure`
 
 `listener`: (Required) Setting your notification listener details
 - `baseURL`: *string* - (Required) the url where your endpoint is hosted

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -15,7 +15,7 @@ The configuration object is required as an argument when creating the TESjs inst
 - `secret`: *string* - (Required) your app's client secret (make sure this is not in plaintext, use environment variables for this)
 - `onAuthenticationFailure`: *function* - (Optional) if you already have an authentication solution for your app elsewhere use this to avoid token conflicts
   - This function should return a Promise that resolves an app access token
-- `accessToken`: *string* (Optional) if you already have an app access token at the time of initing TESjs, you can pass it here
+- `accessToken`: *string* - (Optional) if you already have an app access token at the time of initing TESjs, you can pass it here
   - This should usually be paired with `onAuthenticationFailure`
 
 `listener`: (Required) Setting your notification listener details

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -10,8 +10,10 @@ const AUTH_API_URL = "https://id.twitch.tv/oauth2";
 
 class AuthManager {
     constructor({ clientID, clientSecret, onAuthFailure, initialToken }) {
-        if (!onAuthFailure && !clientID && !clientSecret) {
-            throw new Error("AuthManager config must contain client ID and secret if onAuthFailure not defined");
+        if (!onAuthFailure) {
+            if (!clientID || !clientSecret) {
+                throw new Error("AuthManager config must contain client ID and secret if onAuthFailure not defined");
+            }
         }
 
         if (AuthManager._instance) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ const logger = require("./logger");
 const AUTH_API_URL = "https://id.twitch.tv/oauth2";
 
 class AuthManager {
-    constructor(clientID, clientSecret) {
+    constructor(clientID, clientSecret, onAuthFailure, initialToken) {
         if (AuthManager._instance) {
             return AuthManager._instance;
         }
@@ -18,10 +18,15 @@ class AuthManager {
         this._clientID = clientID;
         this._clientSecret = clientSecret;
 
-        this._authToken;
         this._validationInterval;
 
-        this.refreshToken();
+        this._customRefresh = onAuthFailure;
+
+        if (initialToken) {
+            this._authToken = initialToken;
+        } else {
+            this.refreshToken();
+        }
     }
 
     static getInstance() {
@@ -62,17 +67,21 @@ class AuthManager {
         logger.debug("Getting new app access token");
         try {
             this._authToken = undefined; // set current token undefined to prevent API calls from using stale token
-            const res = await fetch(
-                `${AUTH_API_URL}/token?client_id=${this._clientID}&client_secret=${this._clientSecret}&grant_type=client_credentials`,
-                { method: "POST" }
-            );
-            if (res.ok) {
-                const { access_token } = await res.json();
-                this._authToken = access_token;
-                this._resetValidationInterval();
+            if (this._customRefresh) {
+                this._authToken = await this._customRefresh();
             } else {
-                const { message } = await res.json();
-                throw new Error(message);
+                const res = await fetch(
+                    `${AUTH_API_URL}/token?client_id=${this._clientID}&client_secret=${this._clientSecret}&grant_type=client_credentials`,
+                    { method: "POST" }
+                );
+                if (res.ok) {
+                    const { access_token } = await res.json();
+                    this._authToken = access_token;
+                    this._resetValidationInterval();
+                } else {
+                    const { message } = await res.json();
+                    throw new Error(message);
+                }
             }
         } catch (err) {
             logger.error(`Error refreshing app access token: ${err.message}`);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,11 +9,15 @@ const logger = require("./logger");
 const AUTH_API_URL = "https://id.twitch.tv/oauth2";
 
 class AuthManager {
-    constructor(clientID, clientSecret, onAuthFailure, initialToken) {
+    constructor({ clientID, clientSecret, onAuthFailure, initialToken }) {
         if (AuthManager._instance) {
             return AuthManager._instance;
         }
         AuthManager._instance = this;
+
+        if (!onAuthFailure && !clientID && !clientSecret) {
+            throw new Error("AuthManager config must contain client ID and secret if onAuthFailure not defined");
+        }
 
         this._clientID = clientID;
         this._clientSecret = clientSecret;
@@ -67,6 +71,7 @@ class AuthManager {
         logger.debug("Getting new app access token");
         try {
             this._authToken = undefined; // set current token undefined to prevent API calls from using stale token
+            // if we have a custom refresh function passed through onAuthenticationFailure, use that
             if (this._customRefresh) {
                 this._authToken = await this._customRefresh();
             } else {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -10,14 +10,14 @@ const AUTH_API_URL = "https://id.twitch.tv/oauth2";
 
 class AuthManager {
     constructor({ clientID, clientSecret, onAuthFailure, initialToken }) {
+        if (!onAuthFailure && !clientID && !clientSecret) {
+            throw new Error("AuthManager config must contain client ID and secret if onAuthFailure not defined");
+        }
+
         if (AuthManager._instance) {
             return AuthManager._instance;
         }
         AuthManager._instance = this;
-
-        if (!onAuthFailure && !clientID && !clientSecret) {
-            throw new Error("AuthManager config must contain client ID and secret if onAuthFailure not defined");
-        }
 
         this._clientID = clientID;
         this._clientSecret = clientSecret;

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -33,7 +33,7 @@ class TES {
         if (!config.listener) throw new Error("TES config must contain 'listener'");
 
         const {
-            identity: { id, secret },
+            identity: { id, secret, onAuthenticationFailure, accessToken },
             listener: { baseURL, secret: whSecret, port, ignoreDuplicateMessages, ignoreOldMessages, server },
         } = config;
 
@@ -60,7 +60,7 @@ class TES {
         config.options.debug && logger.setLevel("debug");
         config.options.logging === false && logger.setLevel("none");
 
-        new AuthManager(id, secret);
+        new AuthManager(id, secret, onAuthenticationFailure, accessToken);
     }
 
     /**

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -60,7 +60,12 @@ class TES {
         config.options.debug && logger.setLevel("debug");
         config.options.logging === false && logger.setLevel("none");
 
-        new AuthManager(id, secret, onAuthenticationFailure, accessToken);
+        new AuthManager({
+            clientID: id,
+            clientSecret: secret,
+            onAuthFailure: onAuthenticationFailure,
+            initialToken: accessToken,
+        });
     }
 
     /**

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -17,17 +17,6 @@ const SUBS_API_URL = "https://api.twitch.tv/helix/eventsub/subscriptions";
  */
 class TES {
     constructor(config) {
-        // TES singleton
-        if (TES._instance) {
-            return TES._instance;
-        }
-
-        if (!(this instanceof TES)) {
-            return new TES(config);
-        }
-
-        TES._instance = this;
-
         // ensure we have an identity
         if (!config.identity) throw new Error("TES config must contain 'identity'");
         if (!config.listener) throw new Error("TES config must contain 'listener'");
@@ -41,6 +30,17 @@ class TES {
         if (!secret) throw new Error("TES identity config must contain 'secret'");
         if (!baseURL) throw new Error("TES listener config must contain 'baseURL'");
         if (!whSecret) throw new Error("TES listener config must contain 'secret'");
+
+        // TES singleton
+        if (TES._instance) {
+            return TES._instance;
+        }
+
+        if (!(this instanceof TES)) {
+            return new TES(config);
+        }
+
+        TES._instance = this;
 
         this.clientID = id;
         this.clientSecret = secret;

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -11,7 +11,6 @@ const { objectShallowEquals } = require("./utils");
 const logger = require("./logger");
 
 const SUBS_API_URL = "https://api.twitch.tv/helix/eventsub/subscriptions";
-const AUTH_API_URL = "https://id.twitch.tv/oauth2";
 
 /**
  *  Twitch EventSub

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tesjs",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tesjs",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "express": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,6 +1,5 @@
 const { expect } = require("chai");
 const nock = require("nock");
-const sinon = require("sinon");
 const AuthManager = require("../lib/auth");
 const { buildObjectWithoutKey } = require("./testUtil");
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,10 +1,17 @@
 const { expect } = require("chai");
 const nock = require("nock");
+const sinon = require("sinon");
 const AuthManager = require("../lib/auth");
+const { buildObjectWithoutKey } = require("./testUtil");
 
 describe("AuthManager", () => {
     const expected1 = "test_token";
     const expected2 = "refreshed_token";
+
+    const baseConfig = {
+        clientID: "testID",
+        clientSecret: "testSecret",
+    };
 
     let auth;
     beforeEach(() => {
@@ -20,7 +27,7 @@ describe("AuthManager", () => {
                 refresh = true;
                 return { access_token: expected1 };
             });
-        auth = new AuthManager("testID", "testSecret");
+        auth = new AuthManager(baseConfig);
     });
 
     afterEach(() => {
@@ -57,5 +64,35 @@ describe("AuthManager", () => {
 
         token = await auth.getToken();
         expect(token).to.eq(expected2);
+    });
+
+    it("errors when 'clientID' or 'clientSecret' are not defined and 'onAuthFailure' is not defined", async () => {
+        AuthManager._instance = undefined;
+        expect(() => new AuthManager()).to.throw(Error);
+        expect(() => new AuthManager({})).to.throw(Error);
+        expect(() => new AuthManager({ initialToken: "initial_token" })).to.throw(Error);
+        expect(() => new AuthManager(buildObjectWithoutKey(baseConfig, "clientID"))).to.throw(Error);
+        expect(() => new AuthManager(buildObjectWithoutKey(baseConfig, "clientSecret"))).to.throw(Error);
+    });
+
+    it("uses custom refresh function when present", async () => {
+        AuthManager._instance = undefined;
+        const expected = "custom_token";
+        const customTokenRefresh = async () => {
+            return expected;
+        };
+
+        auth = new AuthManager({ ...baseConfig, onAuthFailure: customTokenRefresh });
+        const token = await auth.getToken();
+        expect(token).to.eq(expected);
+    });
+
+    it("uses initial auth token when present", async () => {
+        AuthManager._instance = undefined;
+        const expected = "initial_token";
+
+        auth = new AuthManager({ ...baseConfig, initialToken: expected });
+        const token = await auth.getToken();
+        expect(token).to.eq(expected);
     });
 });

--- a/test/request.js
+++ b/test/request.js
@@ -43,7 +43,7 @@ describe("RequestManager", () => {
                     return [401, { message: "invalid token" }];
                 }
             });
-        new AuthManager("testID", "testSecret");
+        new AuthManager({ clientID: "testID", clientSecret: "testSecret" });
 
         const { data } = await RequestManager.request(TEST_URL, { method: "POST", headers: {} });
         expect(requested).to.eq(true);


### PR DESCRIPTION
# Description

This PR adds the `onAuthenticationFailure` config option, as well as the `accessToken` config option.  These can both be used for external auth handling.  If  `onAuthenticationFailure` is passed to TESjs, it will be used to refresh the app access token when a 401 response is received by a request made to Twitch.  Both of these config options reside in the `identity` object, and are optional.  It is recommended to pass `onAuthenticationFailure` if TESjs is being used in conjunction with other things that utilize the Twitch API.

This is a non-breaking addition to TESjs

## Additions
- `identity.onAuthenticationFailure`
  - this is a function called when needing to refresh the app access token being used by TESjs
  - it should return a Promise which resolves the app access token
  - closes #47 
- `identity.accessToken`
  - this can be used to pass in an existing app access token to TESjs at initialization
  - if doing this, it is also recommended to use `onAuthenticationFailure`

## Changes
- AuthManager constructor changed to take an object as only argument
  - will throw an error if `onAuthFailure` is undefined and either `clientID` or `clientSecret` is not defined
  - this is internal, and will not affect consumers of TESjs
- Updated TES constructor to throw config errors before initializing the `_instance` variable
  
## Testing
- updated tests to accommodate AuthManager changes
- added new tests related to external auth handling
