### PR TITLE
#58: Only Queue Subscription if Response OK

### DIFF
--- a/lib/tes.js
+++ b/lib/tes.js
@@ -7,7 +7,7 @@ const whserver = require("./whserver");
 const EventManager = require("./events");
 const AuthManager = require("./auth");
 const RequestManager = require("./request");
-const { objectShallowEquals } = require("./utils");
+const { objectShallowEquals, printObject } = require("./utils");
 const logger = require("./logger");
 
 const SUBS_API_URL = "https://api.twitch.tv/helix/eventsub/subscriptions";
@@ -126,7 +126,7 @@ class TES {
         if (args.length === 1) {
             logger.debug(`Getting subscription for id ${idOrType}`);
         } else {
-            logger.debug(`Getting subscription for type ${idOrType} and condition ${condition}`);
+            logger.debug(`Getting subscription for type ${idOrType} and condition ${printObject(condition)}`);
         }
 
         let sub;
@@ -164,7 +164,7 @@ class TES {
      * @param {Object} condition the event condition
      */
     async subscribe(type, condition) {
-        logger.debug(`Subscribing to topic with type ${type} and condition ${condition}`);
+        logger.debug(`Subscribing to topic with type ${type} and condition ${printObject(condition)}`);
         const token = await AuthManager.getInstance().getToken();
         const headers = {
             "Client-ID": this.clientID,
@@ -215,7 +215,7 @@ class TES {
         } else if (arguments.length === 2) {
             const type = args[0];
             const condition = args[1];
-            logger.debug(`Unsubscribing from topic with type ${type} and condition ${condition}`);
+            logger.debug(`Unsubscribing from topic with type ${type} and condition ${printObject(condition)}`);
             const sub = await this.getSubscription(type, condition);
             if (sub) {
                 return unsub(sub.id);

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -186,7 +186,12 @@ class TES {
             body: JSON.stringify(body),
             headers,
         });
-        return new Promise((resolve, reject) => EventManager.queueSubscription(data, resolve, reject));
+        if (data.data) {
+            return new Promise((resolve, reject) => EventManager.queueSubscription(data, resolve, reject));
+        } else {
+            const { error, status, message } = data;
+            throw new Error(`${status} ${error}: ${message}`);
+        }
     }
 
     /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+const { inspect } = require("util");
+
 module.exports = {
     objectShallowEquals: (obj1, obj2) => {
         let isEq = Object.entries(obj1).every(([key, value]) => {
@@ -20,5 +22,8 @@ module.exports = {
             });
         }
         return isEq;
+    },
+    printObject: (obj) => {
+        return inspect(obj, { breakLength: Infinity });
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tesjs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tesjs",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "express": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tesjs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A module to streamline the use of Twitch EventSub in Node.js applications",
   "repository": {
     "type": "git",

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -48,7 +48,7 @@ describe("whserver", () => {
 
     it("responds with 403 to request with signature mismatch", async () => {
         const out = await cmd(`twitch event trigger subscribe -F ${REDIRECT_URL} -s wrongsecret`);
-        expect(out).to.contain("Recieved Status Code: 403");
+        expect(out).to.contain("Received Status Code: 403");
         expect(out).to.contain("Request signature mismatch");
     });
 


### PR DESCRIPTION
# Description

Previously, TESjs was  too optimistic in assuming developers will know to give correct auth scopes to their client, and that subscriptions are cleaned up. So, it passed the subscribe response naively to the subscription queue assuming it was OK.  This changes that to only queue a subscription if `data` is present on the response.

## Changes
- only queue subscription if `data` present on response
  - throws error with format `<status> <error>: <message>` if not
  - closes #58 
- pretty print objects now
  - no more `[object Object]` yay!
  
## Testing
Manual tests to check output, automated tests should still pass
