### PR TITLE
Update whserver Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Install Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
     - run: brew install twitchdev/twitch/twitch-cli
     - run: npm ci
     - run: npm run build --if-present

--- a/test/test_environment.js
+++ b/test/test_environment.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { cmd } = require("./testUtil");
 
 describe("Test Environment", () => {
-    it("has required twitch CLI installed", async () => {
+    it("has the twitch CLI installed", async () => {
         try {
             const out = await cmd("twitch version");
-            expect(out).to.contain("1.1.12");
+            expect(out).to.not.be.undefined;
         } catch (err) {
             throw new Error("Twitch CLI not installed");
         }

--- a/test/test_environment.js
+++ b/test/test_environment.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const { cmd } = require("./testUtil");
 
 describe("Test Environment", () => {
-    it("has the twitch CLI installed", async () => {
+    it("has required twitch CLI installed", async () => {
         try {
             const out = await cmd("twitch version");
-            expect(out).to.not.be.undefined;
+            expect(out).to.contain("1.1.12");
         } catch (err) {
             throw new Error("Twitch CLI not installed");
         }

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -2,7 +2,6 @@ const TES = require("../main");
 const request = require("supertest");
 const nock = require("nock");
 const sinon = require("sinon");
-const crypto = require("crypto");
 const { cmd } = require("./testUtil");
 const { expect } = require("chai");
 const AuthManager = require("../lib/auth");
@@ -57,8 +56,10 @@ describe("whserver", () => {
             .post("/helix/eventsub/subscriptions")
             .reply(201, () => {
                 setTimeout(async () => {
-                    const out = await cmd(`twitch event verify channel.update -F ${REDIRECT_URL} -s ${whSecret}`);
-                    expect(out).to.contain("Valid response");
+                    const out = await cmd(`twitch event verify channel.update -F ${REDIRECT_URL} -s ${whSecret} -u 1`);
+                    expect(out).to.contain("Valid response.");
+                    expect(out).to.contain("Valid content-type header.");
+                    expect(out).to.contain("Valid status code.");
                     done();
                 });
                 return {
@@ -76,54 +77,11 @@ describe("whserver", () => {
         sinon.assert.called(cb);
     });
 
-    // TODO: update when able to send a revocation notification in Twitch CLI
-    it("responds with 200 OK when receiving a revocation and the revocation event should be fired", (done) => {
-        let notificationRecieved = false;
-        tes.on("revocation", () => {
-            notificationRecieved = true;
-        });
-        const payload = {
-            subscription: {
-                id: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
-                status: "authorization-revoked",
-                type: "channel.follow",
-                version: "1",
-                condition: {
-                    broadcaster_user_id: "12826",
-                },
-                transport: {
-                    method: "webhook",
-                    callback: "https://example.com/webhooks/callback",
-                },
-                created_at: "2019-11-16T10:11:12.123Z",
-            },
-            limit: 10000,
-            total: 1,
-            pagination: {},
-        };
-        const signature = crypto
-            .createHmac("sha256", whSecret)
-            .update("84c1e79a-2a4b-4c13-ba0b-4312293e9308" + timestamp + Buffer.from(JSON.stringify(payload), "utf-8"))
-            .digest("hex");
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "84c1e79a-2a4b-4c13-ba0b-4312293e9308",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "revocation",
-                "Twitch-Eventsub-Message-Signature": `sha256=${signature}`,
-                "Twitch-Eventsub-Message-Timestamp": timestamp,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send(payload)
-            .expect(200)
-            .end((err, { text }) => {
-                if (err) return done(err);
-                expect(text).to.eq("OK");
-                expect(notificationRecieved).to.eq(true);
-                done();
-            });
+    it("responds with 200 OK when receiving a revocation and the revocation event should be fired", async () => {
+        const cb = sinon.spy();
+        tes.on("revocation", cb);
+        await cmd(`twitch event trigger channel.follow -F ${REDIRECT_URL} -s ${whSecret} -r authorization_revoked`);
+        sinon.assert.called(cb);
     });
 
     it("responds with 200 OK when receiving a duplicate notification and the event should not be fired", async () => {
@@ -139,56 +97,11 @@ describe("whserver", () => {
         sinon.assert.calledOnce(spy);
     });
 
-    // TODO: update when able to set timestamps in Twitch CLI
-    it("responds with 200 OK when receiving an old notification and the event should not be fired", (done) => {
-        let notificationRecieved = false;
-        tes.on("channel.follow", () => {
-            notificationRecieved = true;
-        });
-        const payload = {
-            subscription: {
-                id: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
-                type: "channel.follow",
-                version: "1",
-                condition: {
-                    broadcaster_user_id: "12826",
-                },
-                transport: {
-                    method: "webhook",
-                    callback: "https://example.com/webhooks/callback",
-                },
-                created_at: "2019-11-16T10:11:12.123Z",
-            },
-            event: {
-                user_id: "1337",
-                user_name: "awesome_user",
-                broadcaster_user_id: "12826",
-                broadcaster_user_name: "twitch",
-            },
-        };
-        const oldTime = new Date(Date.now() - 601000).toISOString();
-        const signature = crypto
-            .createHmac("sha256", whSecret)
-            .update("befa7b53-d79d-478f-86b9-120f112b044d" + oldTime + Buffer.from(JSON.stringify(payload), "utf-8"))
-            .digest("hex");
-        request(app)
-            .post("/teswh/event")
-            .set({
-                "Twitch-Eventsub-Message-Id": "befa7b53-d79d-478f-86b9-120f112b044d",
-                "Twitch-Eventsub-Message-Retry": 0,
-                "Twitch-Eventsub-Message-Type": "notification",
-                "Twitch-Eventsub-Message-Signature": `sha256=${signature}`,
-                "Twitch-Eventsub-Message-Timestamp": oldTime,
-                "Twitch-Eventsub-Subscription-Type": "channel.follow",
-                "Twitch-Eventsub-Subscription-Version": 1,
-            })
-            .send(payload)
-            .expect(200)
-            .end((err, { text }) => {
-                if (err) return done(err);
-                expect(text).to.eq("OK");
-                expect(notificationRecieved).to.eq(false);
-                done();
-            });
+    it("responds with 200 OK when receiving an old notification and the event should not be fired", async () => {
+        const oldTimestamp = new Date(Date.now() - 601000).toISOString();
+        const cb = sinon.spy();
+        tes.on("channel.follow", cb);
+        sinon.assert.notCalled(cb);
+        await cmd(`twitch event trigger channel.follow -F ${REDIRECT_URL} -s ${whSecret} --timestamp ${oldTimestamp}`);
     });
 });

--- a/test/whserver.js
+++ b/test/whserver.js
@@ -101,7 +101,7 @@ describe("whserver", () => {
         const oldTimestamp = new Date(Date.now() - 601000).toISOString();
         const cb = sinon.spy();
         tes.on("channel.follow", cb);
-        sinon.assert.notCalled(cb);
         await cmd(`twitch event trigger channel.follow -F ${REDIRECT_URL} -s ${whSecret} --timestamp ${oldTimestamp}`);
+        sinon.assert.notCalled(cb);
     });
 });


### PR DESCRIPTION
# Description

Updates the `whserver` tests to use new features from Twitch CLI `v1.1.12`.  This greatly simplifies the tests, and makes them more correct.

## Changes
- uses new features in Twitch CLI `v1.1.12`
  - `-u` flag on `twitch event verify` to set subscription id
  - `--timestamp` flag on `twitch event trigger` to set an old timestamp
  - `-r` flag on `twitch event trigger` to trigger a `revocation` event
  
## Testing
Updated tests are passing
