### PR TITLE
docs: Fix code snippet for getSubscriptionsByStatus

### DIFF
--- a/doc/tesjs.md
+++ b/doc/tesjs.md
@@ -124,8 +124,8 @@ Get a list of your event subscriptions by status
 
 **Example**  
 ```js
-const subs = await tes.getSubscriptionsByType("channel.update");
-console.log(`I have ${subs.total} "channel.update" event subscriptions`);
+const subs = await tes.getSubscriptionsByStatus("enabled");
+console.log(`I have ${subs.total} "enabled" event subscriptions`);
 ```
 
 * * *

--- a/lib/tes.js
+++ b/lib/tes.js
@@ -233,8 +233,8 @@ class TES {
      * @returns {Promise} Subscription data. See [Twitch doc](https://dev.twitch.tv/docs/api/reference/#get-eventsub-subscriptions) for details
      * @example
      * ```js
-     * const subs = await tes.getSubscriptionsByType("channel.update");
-     * console.log(`I have ${subs.total} "channel.update" event subscriptions`);
+     * const subs = await tes.getSubscriptionsByStatus("enabled");
+     * console.log(`I have ${subs.total} "enabled" event subscriptions`);
      * ```
      */
     getSubscriptionsByStatus(status, cursor) {


### PR DESCRIPTION
# Description

This pull request fixes the code snippet for `getSubscriptionsByStatus`, as it used to be the same as `getSubscriptionsByType`.

## Additions
- None

## Changes
- tesjs.md
  - Fixes the `getSubscriptionsByStatus` code snippet
  
## Testing
I didn't find any documentation tests, but it looks correct to me.